### PR TITLE
Added some more info about the migration procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ This version supports ONLY version of mongoid ~> 2.1
 
 You can use `upload_identifier` to retrieve the original name of the uploaded file.
 
-The default mount column used to be `upload_filename` and now is simply `upload`. 
+The default mount column used to be the name of the upload column plus  `_filename`. Now it is simply the name of the column. Most of the time, the column was called `upload`, so it would have been mounted to `upload_filename`.
 If you'd like to avoid a database migration, simply use the `:mount_on` option to specify
-the field name explicitly. For example:
+the field name explicitly. Therefore, you only have to add a `_filename` to your column name. For example, if your column is called `:upload`:
 
 ```ruby
 class Dokument


### PR DESCRIPTION
Added info about the old _filename convention, because this could lead to some trouble if people migrate from 0.5.5 to the new carrierwave-mongoid gem and do not have a column :upload but e.g. :myupload and do not realize that they need to add a :mount_on => :myupload_filename and not a :mount_on => :upload_filename.
Maybe it's clear for most of the people, but don't you think it would be helpful for "beginners"?
