### PR TITLE
When saving embedded document, all changes in parent were reset

### DIFF
--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -41,7 +41,8 @@ module CarrierWave
         def find_previous_model_for_#{column}
           if self.embedded?
             ancestors       = [[ self.metadata.key, self._parent ]].tap { |x| x.unshift([ x.first.last.metadata.key, x.first.last._parent ]) while x.first.last.embedded? }
-            reloaded_parent = ancestors.first.last.reload
+            first_parent = ancestors.first.last
+            reloaded_parent = first_parent.class.find(first_parent.to_key.first)
             ancestors.inject(reloaded_parent) { |parent,(key,ancestor)| (parent.is_a?(Array) ? parent.find(ancestor.to_key.first) : parent).send(key) }.find(to_key.first)
           else
             self.class.find(to_key.first)

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -450,6 +450,14 @@ describe CarrierWave::Mongoid do
         File.exists?(public_path('uploads/old.jpeg')).should be_true
       end
 
+      it "should not touch parent's dirty attributes" do
+        @class.field :title
+        @doc.title = "Title"
+        @embedded_doc.image = stub_file('new.jpeg')
+        @embedded_doc.save.should be_true
+        @doc.title.should == "Title"
+      end
+
       describe 'with double embedded documents' do
 
         before do


### PR DESCRIPTION
I fix this, so `remove_previously_stored_#{column}` will work with another copy of document.
