### PR TITLE
CarrierWave::Uploader::Proxy expects storage to respond_to :size

### DIFF
--- a/lib/carrierwave/storage/grid_fs.rb
+++ b/lib/carrierwave/storage/grid_fs.rb
@@ -77,6 +77,7 @@ module CarrierWave
         def file_length
           grid.open(@path, 'r').file_length
         end
+        alias :size :file_length
 
       protected
 


### PR DESCRIPTION
Without this fix mounted_asset.size will always return zero when used with GridFS.
