### PR TITLE
Squeeze extra slashes which confuse GridFS

### DIFF
--- a/lib/carrierwave/storage/grid_fs.rb
+++ b/lib/carrierwave/storage/grid_fs.rb
@@ -52,7 +52,7 @@ module CarrierWave
           unless @uploader.grid_fs_access_url
             nil
           else
-            [@uploader.grid_fs_access_url, @path].join("/")
+            [@uploader.grid_fs_access_url, @path].join("/").squeeze("/")
           end
         end
 


### PR DESCRIPTION
Following our discussion about File.join, I changed it just to eat the extra slashes. I hope that you can accept this w/o unit test :)
