### PR TITLE
Improve the "Known issues and limitations"

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,6 @@ end
 
 ## Known issues and limitations
 
-Note that embedded documents files aren't saved when parent documents are saved.
+Note that files mounted in embedded documents aren't saved when parent documents are saved.
 You must explicitly call save on embedded documents in order to save their attached files.
 You can read more about this [here](https://github.com/jnicklas/carrierwave/issues#issue/81)


### PR DESCRIPTION
I've improved the _Known issues and limitations_ section by:
1. Removing the note about disabling Mongoid's auto-validation. This doesn't apply to Mongoid.
2. Slightly rewording the paragraph about embedded docs.
