### PR TITLE
Mongoid 3.0-support

### DIFF
--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", [">= 0.5.6"]
-  s.add_dependency "mongoid", ["~> 2.1"]
+  s.add_dependency "mongoid", [">= 2.1"]
   s.add_development_dependency "rspec", ["~> 2.6"]
   s.add_development_dependency "bson_ext", ["~> 1.3"]
   s.add_development_dependency "rake", ["~> 0.9"]


### PR DESCRIPTION
I'm testing out mongoid 3.0 in a project here and noticed that the carrierwave-mongoid gem wasn't playing ball with that version.

I've created a mongoid_3_0 branch in my fork - as for now I've only bumped the version number in the gemspec, but there might be other things as well. I'm using both mongoid (3.0 master) and carrierwave-mongoid in a project here so I'll commit more fixes to this branch if I find any other problems. This probably shouldn't be pulled until mongoid 3.0 is ready.
