### PR TITLE
Fix for embed_one documents

### DIFF
--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -43,7 +43,8 @@ module CarrierWave
             ancestors       = [[ self.metadata.key, self._parent ]].tap { |x| x.unshift([ x.first.last.metadata.key, x.first.last._parent ]) while x.first.last.embedded? }
             first_parent = ancestors.first.last
             reloaded_parent = first_parent.class.find(first_parent.to_key.first)
-            ancestors.inject(reloaded_parent) { |parent,(key,ancestor)| (parent.is_a?(Array) ? parent.find(ancestor.to_key.first) : parent).send(key) }.find(to_key.first)
+            model = ancestors.inject(reloaded_parent) { |parent,(key,ancestor)| (parent.is_a?(Array) ? parent.find(ancestor.to_key.first) : parent).send(key) }
+            model.is_a?(Array) ? model.find(to_key.first) : model
           else
             self.class.find(to_key.first)
           end

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -403,25 +403,7 @@ describe CarrierWave::Mongoid do
       end
     end
 
-    describe 'with embedded documents' do
-
-      before do
-        @embedded_doc_class = define_mongo_class('MongoLocation') do
-          include Mongoid::Document
-          mount_uploader :image, @uploader
-          embedded_in :mongo_user
-        end
-
-        @class.class_eval do
-          embeds_many :mongo_locations
-        end
-
-        @doc = @class.new
-        @embedded_doc = @doc.mongo_locations.build
-        @embedded_doc.image = stub_file('old.jpeg')
-        @embedded_doc.save.should be_true
-      end
-
+    shared_examples "embedded documents" do
       it "should remove old file if old file had a different path" do
         @embedded_doc.image = stub_file('new.jpeg')
         @embedded_doc.save.should be_true
@@ -457,6 +439,49 @@ describe CarrierWave::Mongoid do
         @embedded_doc.save.should be_true
         @doc.title.should == "Title"
       end
+    end
+
+
+    describe 'with document embedded as embeds_one' do
+      before do
+        @embedded_doc_class = define_mongo_class('MongoLocation') do
+          include Mongoid::Document
+          mount_uploader :image, @uploader
+          embedded_in :mongo_user
+        end
+
+        @class.class_eval do
+          embeds_one :mongo_location
+        end
+
+        @doc = @class.new
+        @embedded_doc = @doc.build_mongo_location
+        @embedded_doc.image = stub_file('old.jpeg')
+        @embedded_doc.save.should be_true
+      end
+
+      include_examples "embedded documents"
+    end
+
+    describe 'with embedded documents' do
+      before do
+        @embedded_doc_class = define_mongo_class('MongoLocation') do
+          include Mongoid::Document
+          mount_uploader :image, @uploader
+          embedded_in :mongo_user
+        end
+
+        @class.class_eval do
+          embeds_many :mongo_locations
+        end
+
+        @doc = @class.new
+        @embedded_doc = @doc.mongo_locations.build
+        @embedded_doc.image = stub_file('old.jpeg')
+        @embedded_doc.save.should be_true
+      end
+
+      include_examples "embedded documents"
 
       describe 'with double embedded documents' do
 


### PR DESCRIPTION
If you had an uploader in embedded document that was embedded as embed_one then it fails with 

```
 undefined method `find' for #<MongoLocation:0x007ff585042310>
 # ./lib/carrierwave/mongoid.rb:48:in `find_previous_model_for_image'
```

This fixes that situation.
