### PR TITLE
less pessimistic versioning.

### DIFF
--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "carrierwave", ["~> 0.6.1"]
-  s.add_dependency "mongoid", ["~> 3.0.0"]
-  s.add_dependency "mongoid-grid_fs", ["~> 1.3.1"]
+  s.add_dependency "carrierwave", ["~> 0.6"]
+  s.add_dependency "mongoid", ["~> 3.0"]
+  s.add_dependency "mongoid-grid_fs", ["~> 1.3"]
   s.add_development_dependency "rspec", ["~> 2.6"]
   s.add_development_dependency "rake", ["~> 0.9"]
   s.add_development_dependency "mini_magick"


### PR DESCRIPTION
~> major.minor should be sufficient regardless of how fast mongoid is moving...
