### PR TITLE
Respect options[:except] and options[:only] when passed to to_json

### DIFF
--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -63,7 +63,9 @@ module CarrierWave
         def serializable_hash(options=nil)
           hash = {}
           self.class.uploaders.each do |column, uploader|
-            hash[column.to_s] = _mounter(:#{column}).uploader.serializable_hash
+            if (!options[:only] && !options[:except]) || (options[:only] && options[:only].include?(column)) || (options[:except] && !options[:except].include?(column))
+              hash[column.to_s] = _mounter(:#{column}).uploader.serializable_hash
+            end
           end
           super(options).merge(hash)
         end

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -121,6 +121,20 @@ describe CarrierWave::Mongoid do
         JSON.parse({:data => @doc.image}.to_json).should == {"data"=>{"image"=>{"url"=>"/uploads/test.jpeg"}}}
       end
 
+      it "should respect options[:only] when passed to to_json for the serializable hash" do
+        @doc[:image] = 'test.jpeg'
+        @doc.save!
+        @doc.reload
+        JSON.parse(@doc.to_json({:only => [:_id]})).should == {"_id" => @doc.id.to_s}
+      end
+
+      it "should respect options[:except] when passed to to_json for the serializable hash" do
+        @doc[:image] = 'test.jpeg'
+        @doc.save!
+        @doc.reload
+
+        JSON.parse(@doc.to_json({:except => [:_id, :image]})).should == {"folder" => ""}
+      end
 
     end
 


### PR DESCRIPTION
patch about serializable hash options based on a carrierwave repository patch

issue : https://github.com/jnicklas/carrierwave/issues/663
patch : https://github.com/jnicklas/carrierwave/commit/be594ea374a66be25e0cd63e58176987803ccbc4
