### PR TITLE
Identity map + carrierwave-mongoid problem

### DIFF
--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -56,7 +56,7 @@ module CarrierWave
             association = ancestors.inject(reloaded_parent) { |parent,(key,ancestor)| (parent.is_a?(Array) ? parent.find(ancestor.to_key.first) : parent).send(key) }
             association.is_a?(Array) ? association.find(to_key.first) : association
           else
-            self.class.unscoped.find(to_key.first)
+            self.class.unscoped.for_ids(to_key.first).first
           end
         end
 


### PR DESCRIPTION
When the identity map is enabled, `find_previous_model_for_#{column}` takes the already modified object from the identity map, so we need to use for_ids, as it ignores the identity map. Another way would be to temporarily disable the identity map.
