### PR TITLE
Updated Carrierwave to version 0.7.0

### DIFF
--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "carrierwave", ["~> 0.7.0"]
+  s.add_dependency "carrierwave", ["~> 0.6"]
   s.add_dependency "mongoid", ["~> 3.0.0"]
   s.add_dependency "mongoid-grid_fs", ["~> 1.3.1"]
   s.add_development_dependency "rspec", ["~> 2.6"]


### PR DESCRIPTION
Yeah, that's it. I've just updated the CarrireWave version to it's last verision in the gemspec file. All specs are passing.
