### PR TITLE
bump carrierwave version

### DIFF
--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "carrierwave", ["~> 0.6.1"]
+  s.add_dependency "carrierwave", ["~> 0.7.1"]
   s.add_dependency "mongoid", ["~> 2.1"]
   s.add_development_dependency "rspec", ["~> 2.6"]
   s.add_development_dependency "bson_ext", ["~> 1.3"]


### PR DESCRIPTION
The specs pass fine with the updated version, and this is holding back anyone that wants to use the latest carrierwave with carrierwave-mongoid.
