### PR TITLE
Update dependencies

### DIFF
--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", ["~> 0.7.1"]
-  s.add_dependency "mongoid", ["~> 3.0.0"]
-  s.add_dependency "mongoid-grid_fs", ["~> 1.7.0"]
+  s.add_dependency "mongoid", ["~> 3.0"]
+  s.add_dependency "mongoid-grid_fs", ["~> 1.3"]
   s.add_development_dependency "rspec", ["~> 2.6"]
   s.add_development_dependency "rake", ["~> 10.0"]
   s.add_development_dependency "mini_magick"


### PR DESCRIPTION
This started as a patch to update the `mongoid-grid_fs` dependency to version ~> 1.7.0.

I also took this opportunity to update the `rake` development dependency and specify all runtime dependencies > 1.0 with 2 digits of precision, in keeping with semantic versioning. The `carrierwave` still remains specified with 3 digits of precision, since it is < 1.0 and may still break backward compatibility in minor releases.
