### PR TITLE
Fix to_json / serializable hash issue when using two uploaders on the same model. 

### DIFF
--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -64,8 +64,8 @@ module CarrierWave
         def serializable_hash(options=nil)
           hash = {}
           self.class.uploaders.each do |column, uploader|
-            if (!options[:only] && !options[:except]) || (options[:only] && options[:only].include?(column)) || (options[:except] && !options[:except].include?(column))
-              hash[column.to_s] = _mounter(:#{column}).uploader.serializable_hash
+            if !options || (!options[:only] && !options[:except]) || (options[:only] && options[:only].include?(column)) || (options[:except] && !options[:except].include?(column))
+              hash[column.to_s] = _mounter(column.to_sym).uploader.serializable_hash
             end
           end
           super(options).merge(hash)


### PR DESCRIPTION
1. Added two failing tests that illustrate the problem.
2. Fixed issue by changing serializable hash to use column.to_sym instead of string interpolation (which overwrites the method definition at the time mount_uploader is called)
3. Fix an unrelated issue that caused my tests to fail: check that options are defined before sending :[](which nil doesn't repond to)
