### PR TITLE
Mongoid 3: cascade_callbacks works for save but not update_attributes

### DIFF
--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -676,7 +676,7 @@ describe CarrierWave::Mongoid do
         end
 
         @class.class_eval do
-          embeds_many :mongo_locations
+          embeds_many :mongo_locations, cascade_callbacks: true
           accepts_nested_attributes_for :mongo_locations
         end
 
@@ -689,6 +689,13 @@ describe CarrierWave::Mongoid do
         @doc.reload
         @doc.mongo_locations.first.image.path.should match(/old\.jpeg$/)
         @embedded_doc.image.path.should match(/old\.jpeg$/)
+      end
+
+      it "should update the image on update_attributes" do
+        @doc.update_attributes(mongo_locations_attributes: [{id: @embedded_doc.id, image: stub_file("new.jpeg")}]).should be_true
+        @doc.reload
+        @doc.mongo_locations.first.image.path.should match(/new\.jpeg$/)
+        @embedded_doc.image.path.should match(/new\.jpeg$/)
       end
     end
   end


### PR DESCRIPTION
``` ruby
class Parent
    include Mongoid::Document

   embeds_many :children, cascade_callbacks: true
end

class Child
   include Mongoid::Document

   mount_uploader :image, ImageUploader

   embedded_in :parent
end
```

I am using Mongoid together with carrierwave. I have 2 classes like above. When I create a new Parent. `parent.save` works and the uploaded image got saved to the embedded child. But when I try to update a Parent, I cannot get the image to upload correctly using `Parent.update_attributes()`. 

I opened an [issue](https://github.com/mongoid/mongoid/issues/2448) in mongoid project, but I think the problem probably is in the carrierwave-mongoid side. 
