### PR TITLE
Mounted file from Mongoid::Paranoia document is hard deleted

### DIFF
--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -39,6 +39,10 @@ module CarrierWave
           super
         end
 
+        def remove_#{column}!
+          super unless paranoid? && flagged_for_destroy?
+        end
+
         # Overrides Mongoid's default dirty behavior to instead work more like
         # ActiveRecord's. Mongoid doesn't deem an attribute as changed unless
         # the new value is different than the original. Given that CarrierWave

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -766,6 +766,33 @@ describe CarrierWave::Mongoid do
     end
   end
 
+  describe "with paranoia enabled" do
+    before do
+      @class = reset_mongo_class
+      @class.collection.drop
+      @class.class_eval do
+        include Mongoid::Paranoia
+      end
+
+      @doc = @class.new(image: stub_file("old.jpeg"))
+      @doc.save.should be_true
+    end
+
+    it "should not remove underlying image after #destroy" do
+      @doc.destroy.should be_true
+      @class.count.should eql(0)
+      @class.deleted.count.should eql(1)
+      File.exist?(public_path('uploads/old.jpeg')).should be_true
+    end
+
+    it "should remove underlying image after #destroy!" do
+      @doc.destroy!.should be_true
+      @class.count.should eql(0)
+      @class.deleted.count.should eql(0)
+      File.exist?(public_path('uploads/old.jpeg')).should be_false
+    end
+  end
+
   context "JSON serialization with multiple uploaders" do
     before do
       @class = reset_mongo_class


### PR DESCRIPTION
Hi,

I have mounted an uploader in a document with Mongoid::Paranoia included, to prevent hard deletes. But while the document is softly deleted (i.e. has the deleted_at field set), its mounted file is hard deleted. This makes Mongoid::Paranoia useless when combined with Carrierwave.

``` ruby
  class MyDocument
    include Mongoid::Document
    include Mongoid::Paranoia
    mount_uploader :media, MyUploader

    # ...
  end
```
