### PR TITLE
Add support for mongoid 3.1

### DIFF
--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", ["~> 0.8.0"]
-  s.add_dependency "mongoid", ["~> 3.0"]
+  s.add_dependency "mongoid", [">= 3.0"]
   s.add_dependency "mongoid-grid_fs", ["~> 1.3"]
   s.add_development_dependency "rspec", ["~> 2.6"]
   s.add_development_dependency "rake", ["~> 10.0"]


### PR DESCRIPTION
Specs are passing, mongoid strictly follow SemVer (i.e. 3.1 does not introduce breaking changes) so there shouldn't be a problem with this update until mongoid 4 is released, right?

Cheers,
Carsten
