### PR TITLE
Fix a bug with embedded documents

### DIFF
--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -35,6 +35,10 @@ module CarrierWave
       class_eval <<-RUBY, __FILE__, __LINE__+1
         def #{column}=(new_file)
           column = _mounter(:#{column}).serialization_column
+
+          # mongoid won't upload a new file if there was no file previously.
+          write_uploader(column, '_old_') if self.persisted? && read_uploader(column).nil?
+
           send(:"\#{column}_will_change!")
           super
         end

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -568,7 +568,7 @@ describe CarrierWave::Mongoid do
         end
 
         @class.class_eval do
-          embeds_many :mongo_locations
+          embeds_many :mongo_locations, cascade_callbacks: true
         end
 
         @doc = @class.new
@@ -578,6 +578,17 @@ describe CarrierWave::Mongoid do
       end
 
       include_examples "embedded documents"
+
+      it "attaches a new file to the document which didn't have one at first" do
+        doc = @class.new
+        doc.mongo_locations.build
+        doc.save & doc.reload
+
+        doc.mongo_locations.first.image = stub_file('test.jpeg')
+        doc.save & doc.reload
+
+        doc.mongo_locations.first[:image].should == 'test.jpeg'
+      end
 
       describe 'with double embedded documents' do
 


### PR DESCRIPTION
Hi @jnicklas,

I found a bug when I was upgrading LocomotiveCMS to mongoid 3.x. Actually, mongoid prevents carriewave to attach a file to a embedded document owned by an existing document. It only occurs if the embedded document didn't have a attached file when the parent document was created. A little bit more of explanation here: https://github.com/jnicklas/carrierwave-mongoid/pull/64#issuecomment-17389921

To be honest, I'm not satisfied by my "patch" but anyway, it solves the bug.
Thanks !

  Didier
