### PR TITLE
Add an explicit dependency on mongoid-grid_fs [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Or, in Rails you can add it to your Gemfile:
 gem 'carrierwave-mongoid', :require => 'carrierwave/mongoid'
 ```
 
+If you are using Rails 4.0.0 in your application, be sure to use Mongoid 4.0 and
+to explicitly depends on `mongoid-grid_fs`:
+
+```ruby
+gem 'mongoid-grid_fs', github: 'ahoward/mongoid-grid_fs'
+```
+
 ## Getting Started
 
 Follow the "Getting Started" directions in the main


### PR DESCRIPTION
Hello,

Just a little pull request to add a note about Rails 4.0 applications. Since Rails 4.0 requires Mongoid 4.0 but mongoid-grid_fs depends on Mongoid 3.x for now, we have to checkout the GitHub repository to meet
dependencies.

Have a nice day.
