### PR TITLE
the call to the default attribute_will_change method was not enough when...

### DIFF
--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -57,6 +57,14 @@ module CarrierWave
           changed_attributes.has_key?("#{column}")
         end
 
+        # The default Mongoid attribute_will_change! method is not enough
+        # when we want to upload a new file in an existing embedded document.
+        # The custom version of that method forces the callbacks to be
+        # ran and so does the upload.
+        def #{column}_will_change!
+          changed_attributes["#{column}"] = '_new_'
+        end
+
         def find_previous_model_for_#{column}
           if self.embedded?
             ancestors       = [[ self.metadata.key, self._parent ]].tap { |x| x.unshift([ x.first.last.metadata.key, x.first.last._parent ]) while x.first.last.embedded? }

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -569,6 +569,7 @@ describe CarrierWave::Mongoid do
 
         @class.class_eval do
           embeds_many :mongo_locations, cascade_callbacks: true
+          accepts_nested_attributes_for :mongo_locations
         end
 
         @doc = @class.new
@@ -590,6 +591,12 @@ describe CarrierWave::Mongoid do
         doc.reload
 
         doc.mongo_locations.first[:image].should == 'test.jpeg'
+      end
+
+      it "changes the file" do
+        @doc.update_attributes mongo_locations_attributes: { '0' => { _id: @embedded_doc._id, image: stub_file('test.jpeg') } }
+        @doc.reload
+        @doc.mongo_locations.first[:image].should == 'test.jpeg'
       end
 
       describe 'with double embedded documents' do


### PR DESCRIPTION
... uploading a new file in an embedded document (#64). 

That should solve that very annoying bug: https://github.com/carrierwaveuploader/carrierwave-mongoid/pull/64. 
I added a test (all the tests pass).
