### PR TITLE
Fix typo mongoind-grid_fs to mongoid-grid_fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Or, in Rails you can add it to your Gemfile:
 gem 'carrierwave-mongoid', :require => 'carrierwave/mongoid'
 ```
 
-Note: If using Rails 4, you'll need to make sure `mongoind-grid_fs` is `>= 1.9.0`.
-If in doubt, run `bundle update mongoind-grid_fs`
+Note: If using Rails 4, you'll need to make sure `mongoid-grid_fs` is `>= 1.9.0`.
+If in doubt, run `bundle update mongoid-grid_fs`
 
 ```ruby
 gem 'mongoid-grid_fs', github: 'ahoward/mongoid-grid_fs'


### PR DESCRIPTION
Fix typo. Instructions said mongoind-grid_fs where it should say mongoid-grid_fs.
