### PR TITLE
Fix removing uploaded files in embedded documents.

### DIFF
--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -43,6 +43,12 @@ module CarrierWave
           super
         end
 
+        def remove_#{column}=(arg)
+          column = _mounter(:#{column}).serialization_column
+          send(:"\#{column}_will_change!")
+          super
+        end
+
         def remove_#{column}!
           super unless respond_to?(:paranoid?) && paranoid? && flagged_for_destroy?
         end

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -599,6 +599,12 @@ describe CarrierWave::Mongoid do
         @doc.mongo_locations.first[:image].should == 'test.jpeg'
       end
 
+      it "removes a file" do
+        @doc.update_attributes mongo_locations_attributes: { '0' => { _id: @embedded_doc._id, remove_image: "1" } }
+        @doc.reload
+        @doc.mongo_locations.first[:image].should_not be_present
+      end
+
       describe 'with double embedded documents' do
 
         before do


### PR DESCRIPTION
Sending `remove_file = "1"` to an embedded document does not work: Mongoid won’t consider the document dirty and so `save` won’t do anything. (Note that this bug only occurs if there are no other changes to the document.)

I'm not 100% sure how this relates to https://github.com/carrierwaveuploader/carrierwave-mongoid/pull/95 – calling `uploader_column_will_change!` seems to suffice in this case.
