### PR TITLE
Fix future builds since i18n has change

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,13 +46,16 @@ module CarrierWave
     module I18nHelpers
       def change_locale_and_store_translations(locale, translations, &block)
         current_locale = I18n.locale
+        current_enforce = I18n.config.enforce_available_locales
         begin
+          I18n.config.enforce_available_locales = false
           I18n.backend.store_translations locale, translations
           I18n.locale = locale
           yield
         ensure
           I18n.reload!
           I18n.locale = current_locale
+          I18n.config.enforce_available_locales = current_enforce
         end
       end
     end


### PR DESCRIPTION
The dependencies are not being locked and this allowed i18n to be updated to version that enforces available locales.

Please check the [CHANGELOG](https://github.com/svenfuchs/i18n/blob/a69c73d21bd7806a91a65676b2c9e122f3d45faf/CHANGELOG.md) for `i18n-0.7.0`.