### PR TITLE
Support for multiple uploaders per column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 pkg/*
 *.gem
 *.sw*
+.idea
 .bundle
 spec/public
 .rvmrc

--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -89,18 +89,24 @@ module CarrierWave
           end
         end
 
-        def serializable_hash(options=nil)
-          hash = {}
-
-          except = options && options[:except] && Array.wrap(options[:except]).map(&:to_s)
-          only   = options && options[:only]   && Array.wrap(options[:only]).map(&:to_s)
-
-          self.class.uploaders.each do |column, uploader|
-            if (!only && !except) || (only && only.include?(column.to_s)) || (except && !except.include?(column.to_s))
-              hash[column.to_s] = _mounter(column.to_sym).uploader.serializable_hash
+        def serializable_hash(options = nil)
+          super(options).tap do |result_hash|
+            self.class.uploaders.each do |column, _|
+              if result_hash.has_key?(column.to_s) || result_hash.has_key?(column)
+                serialized_key = result_hash.has_key?(column.to_s) ? column.to_s : column
+                column_uploaders = _mounter(column.to_sym).uploaders
+                result_hash[serialized_key] = if column_uploaders.count > 1
+                  column_uploaders.map(&:serializable_hash)
+                else
+                  if column_uploader = column_uploaders.first
+                    column_uploader.serializable_hash
+                  else
+                    {}
+                  end
+                end
+              end
             end
           end
-          super(options).merge(hash)
         end
       RUBY
     end


### PR DESCRIPTION
Hi, I've spotted an exception when I've upgraded to the latest CarrierWave saying there's no `uploader` method for a mounter.
It turned out that `serializable_hash` method had no support of multiple uploaders per column, so I made this update.
