### PR TITLE
latest rspec and rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,9 @@
-require 'bundler/setup'
-Bundler::GemHelper.install_tasks
+require "bundler/gem_tasks"
 
-require 'rspec/core/rake_task'
-
-desc "Run all examples"
-RSpec::Core::RakeTask.new(:spec) do |t|
-  #t.rspec_path = 'bin/rspec'
-  t.rspec_opts = %w[--color]
+begin
+  require "rspec/core/rake_task"
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
 end
 
 task :default => :spec

--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |s|
   s.add_dependency "carrierwave", [">= 0.8.0", "< 0.12.0"]
   s.add_dependency "mongoid", [">= 3.0", "< 6.0"]
   s.add_dependency "mongoid-grid_fs", [">= 1.3", "< 3.0"]
-  s.add_development_dependency "rspec", ["~> 2.14"]
-  s.add_development_dependency "rake", ["~> 10.0"]
+  s.add_development_dependency "rspec", "~>3.4.0"
+  s.add_development_dependency "rake", "~>11.1.2"
   s.add_development_dependency "mini_magick"
   s.add_development_dependency "pry"
 end

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 require 'spec_helper'
 
-require 'carrierwave/mongoid'
-
 def reset_mongo_class(uploader = MongoUploader)
   define_mongo_class('MongoUser') do
     include Mongoid::Document
@@ -59,7 +57,7 @@ describe CarrierWave::Mongoid do
       end
 
       it "returns a blank uploader" do
-        @document.image.should be_blank
+        expect(@document.image).to be_blank
       end
 
     end
@@ -74,7 +72,7 @@ describe CarrierWave::Mongoid do
 
       it "returns a blank uploader" do
         @saved_doc = MongoUser.first
-        @saved_doc.image.should be_blank
+        expect(@saved_doc.image).to be_blank
       end
 
     end
@@ -91,19 +89,19 @@ describe CarrierWave::Mongoid do
       end
 
       it "returns an uploader" do
-        @doc.image.should be_an_instance_of(MongoUploader)
+        expect(@doc.image).to be_an_instance_of(MongoUploader)
       end
 
       it "sets the path to the store directory" do
-        @doc.image.current_path.should == public_path('uploads/test.jpg')
+        expect(@doc.image.current_path).to eq public_path('uploads/test.jpg')
       end
 
       it "should return valid JSON when to_json is called when image is nil" do
         @doc[:image] = nil
         hash = JSON.parse(@doc.to_json)
-        hash.keys.should include("image")
-        hash["image"].keys.should include("url")
-        hash["image"]["url"].should be_nil
+        expect(hash.keys).to include("image")
+        expect(hash["image"].keys).to include("url")
+        expect(hash["image"]["url"]).to be_nil
       end
 
       it "should return valid JSON when to_json is called when image is present" do
@@ -111,7 +109,7 @@ describe CarrierWave::Mongoid do
         @doc.save!
         @doc.reload
 
-        JSON.parse(@doc.to_json)["image"].should == {"url" => "/uploads/test.jpeg"}
+        expect(JSON.parse(@doc.to_json)["image"]).to eq("url" => "/uploads/test.jpeg")
       end
 
       it "should return valid JSON when to_json is called on a collection containing uploader from a model" do
@@ -119,14 +117,14 @@ describe CarrierWave::Mongoid do
         @doc.save!
         @doc.reload
 
-        JSON.parse({:data => @doc.image}.to_json).should == {"data"=>{"image"=>{"url"=>"/uploads/test.jpeg"}}}
+        expect(JSON.parse({:data => @doc.image}.to_json)).to eq("data"=>{"image"=>{"url"=>"/uploads/test.jpeg"}})
       end
 
       it "should respect options[:only] when passed to to_json for the serializable hash" do
         @doc[:image] = 'test.jpeg'
         @doc.save!
         @doc.reload
-        JSON.parse(@doc.to_json({:only => [:_id]})).should == {"_id" => @doc.id.as_json}
+        expect(JSON.parse(@doc.to_json({:only => [:_id]}))).to eq("_id" => @doc.id.as_json)
       end
 
       it "should respect options[:except] when passed to to_json for the serializable hash" do
@@ -134,7 +132,7 @@ describe CarrierWave::Mongoid do
         @doc.save!
         @doc.reload
 
-        JSON.parse(@doc.to_json({:except => [:_id, :image]})).should == {"folder" => ""}
+        expect(JSON.parse(@doc.to_json({:except => [:_id, :image]}))).to eq("folder" => "")
       end
 
     end
@@ -152,7 +150,7 @@ describe CarrierWave::Mongoid do
 
       it "does not set the value" do
         @doc.image = nil
-        @doc.image.should be_blank
+        expect(@doc.image).to be_blank
       end
 
     end
@@ -161,7 +159,7 @@ describe CarrierWave::Mongoid do
 
       it "does not set the value" do
         @doc.image = ''
-        @doc.image.should be_blank
+        expect(@doc.image).to be_blank
       end
 
     end
@@ -170,16 +168,16 @@ describe CarrierWave::Mongoid do
 
       it "should cache a file" do
         @doc.image = stub_file('test.jpeg')
-        @doc.image.should be_an_instance_of(MongoUploader)
+        expect(@doc.image).to be_an_instance_of(MongoUploader)
       end
 
       it "should write nothing to the database, to prevent overriden filenames to fail because of unassigned attributes" do
-        @doc[:image].should be_nil
+        expect(@doc[:image]).to be_nil
       end
 
       it "should copy a file into into the cache directory" do
         @doc.image = stub_file('test.jpeg')
-        @doc.image.current_path.should =~ /^#{public_path('uploads\/tmp')}/
+        expect(@doc.image.current_path).to match /^#{public_path('uploads\/tmp')}/
       end
 
     end
@@ -192,20 +190,20 @@ describe CarrierWave::Mongoid do
       end
 
       it "should make the document invalid when an integrity error occurs" do
-        @doc.should_not be_valid
+        expect(@doc).to_not be_valid
       end
 
       it "should use I18n for integrity error messages" do
         translations = { mongoid: { errors: { messages: { carrierwave_integrity_error: 'is not of an allowed file type' }}}}
         change_locale_and_store_translations(:en, translations) do
           @doc.valid?
-          @doc.errors[:image].should == ['is not of an allowed file type']
+          expect(@doc.errors[:image]).to eq ['is not of an allowed file type']
         end
 
         translations = { mongoid: { errors: { messages: { carrierwave_integrity_error: 'tipo de imagem não permitido.' }}}}
         change_locale_and_store_translations(:pt, translations) do
           @doc.valid?
-          @doc.errors[:image].should == ['tipo de imagem não permitido.']
+          expect(@doc.errors[:image]).to eq ['tipo de imagem não permitido.']
         end
       end
     end
@@ -218,20 +216,20 @@ describe CarrierWave::Mongoid do
       end
 
       it "should make the document invalid when a processing error occurs" do
-        @doc.should_not be_valid
+        expect(@doc).to_not be_valid
       end
 
       it "should use I18n for processing error messages" do
         translations = { mongoid: { errors: { messages: { carrierwave_processing_error: 'failed to be processed' }}}}
         change_locale_and_store_translations(:en, translations) do
           @doc.valid?
-          @doc.errors[:image].should == ['failed to be processed']
+          expect(@doc.errors[:image]).to eq ['failed to be processed']
         end
 
         translations = { mongoid: { errors: { messages: { carrierwave_processing_error: 'falha ao processar imagem.' }}}}
         change_locale_and_store_translations(:pt, translations) do
           @doc.valid?
-          @doc.errors[:image].should == ['falha ao processar imagem.']
+          expect(@doc.errors[:image]).to eq ['falha ao processar imagem.']
         end
       end
     end
@@ -246,27 +244,27 @@ describe CarrierWave::Mongoid do
 
     it "treats true argument such that attribute is marked as changed" do
       @doc.remove_image = true
-      @doc.should be_image_changed
+      expect(@doc).to be_image_changed
     end
 
     it "treats '1' argument such that attribute is marked as changed" do
       @doc.remove_image = '1'
-      @doc.should be_image_changed
+      expect(@doc).to be_image_changed
     end
 
     it "treats false argument such that attribute is not marked as changed" do
       @doc.remove_image = false
-      @doc.should_not be_image_changed
+      expect(@doc).to_not be_image_changed
     end
 
     it "treats nil argument such that attribute is not marked as changed" do
       @doc.remove_image = nil
-      @doc.should_not be_image_changed
+      expect(@doc).to_not be_image_changed
     end
 
     it "treats '0' argument such that attribute is not marked as changed" do
       @doc.remove_image = '0'
-      @doc.should_not be_image_changed
+      expect(@doc).to_not be_image_changed
     end
   end
 
@@ -274,9 +272,9 @@ describe CarrierWave::Mongoid do
 
     it "after it was initialized with params" do
       doc = reset_mongo_class.new(:image => stub_file('test.jpg'))
-      doc.save.should be_truthy
-      doc.image.should be_an_instance_of(MongoUploader)
-      doc.image.current_path.should == public_path('uploads/test.jpg')
+      expect(doc.save).to be_truthy
+      expect(doc.image).to be_an_instance_of(MongoUploader)
+      expect(doc.image.current_path).to eq public_path('uploads/test.jpg')
     end
 
     before do
@@ -287,8 +285,8 @@ describe CarrierWave::Mongoid do
     context "when no file is assigned" do
 
       it "image is blank" do
-        @doc.save.should be_truthy
-        @doc.image.should be_blank
+        expect(@doc.save).to be_truthy
+        expect(@doc.image).to be_blank
       end
 
     end
@@ -297,16 +295,16 @@ describe CarrierWave::Mongoid do
 
       it "copies the file to the upload directory" do
         @doc.image = stub_file('test.jpg')
-        @doc.save.should be_truthy
-        @doc.image.should be_an_instance_of(MongoUploader)
-        @doc.image.current_path.should == public_path('uploads/test.jpg')
+        expect(@doc.save).to be_truthy
+        expect(@doc.image).to be_an_instance_of(MongoUploader)
+        expect(@doc.image.current_path).to eq public_path('uploads/test.jpg')
       end
 
       it "saves the filename in the database" do
         @doc.image = stub_file('test.jpg')
-        @doc.save.should be_truthy
-        @doc[:image].should == 'test.jpg'
-        @doc.image_identifier.should == 'test.jpg'
+        expect(@doc.save).to be_truthy
+        expect(@doc[:image]).to eq 'test.jpg'
+        expect(@doc.image_identifier).to eq 'test.jpg'
       end
 
       context "when remove_image? is true" do
@@ -315,23 +313,23 @@ describe CarrierWave::Mongoid do
           @doc.image = stub_file('test.jpeg')
           @doc.save
           @doc.remove_image = true
-          @doc.save.should be_truthy
+          expect(@doc.save).to be_truthy
           @doc.reload
-          @doc.image.should be_blank
-          @doc.image_identifier.should be_blank
+          expect(@doc.image).to be_blank
+          expect(@doc.image_identifier).to be_blank
         end
 
       end
 
       it "should mark image as changed when saving a new image" do
-        @doc.image_changed?.should be_falsey
+        expect(@doc.image_changed?).to be_falsey
         @doc.image = stub_file("test.jpeg")
-        @doc.image_changed?.should be_truthy
+        expect(@doc.image_changed?).to be_truthy
         @doc.save
         @doc.reload
-        @doc.image_changed?.should be_falsey
+        expect(@doc.image_changed?).to be_falsey
         @doc.image = stub_file("test.jpg")
-        @doc.image_changed?.should be_truthy
+        expect(@doc.image_changed?).to be_truthy
       end
 
     end
@@ -352,8 +350,8 @@ describe CarrierWave::Mongoid do
       @doc.image = stub_file('test.jpeg')
       @doc.save
       @doc.reload
-      @doc[:image].should == 'test.jpeg'
-      @doc.image_identifier.should == 'test.jpeg'
+      expect(@doc[:image]).to eq 'test.jpeg'
+      expect(@doc.image_identifier).to eq 'test.jpeg'
     end
 
   end
@@ -369,12 +367,12 @@ describe CarrierWave::Mongoid do
 
       it "removes the file from the filesystem" do
         @doc.image = stub_file('test.jpeg')
-        @doc.save.should be_truthy
-        File.exist?(public_path('uploads/test.jpeg')).should be_truthy
-        @doc.image.should be_an_instance_of(MongoUploader)
-        @doc.image.current_path.should == public_path('uploads/test.jpeg')
+        expect(@doc.save).to be_truthy
+        expect(File.exist?(public_path('uploads/test.jpeg'))).to be_truthy
+        expect(@doc.image).to be_an_instance_of(MongoUploader)
+        expect(@doc.image.current_path).to eq public_path('uploads/test.jpeg')
         @doc.destroy
-        File.exist?(public_path('uploads/test.jpeg')).should be_falsey
+        expect(File.exist?(public_path('uploads/test.jpeg'))).to be_falsey
       end
 
     end
@@ -383,13 +381,13 @@ describe CarrierWave::Mongoid do
 
       it "deletes the instance of MongoUser after save" do
         @doc.save
-        MongoUser.count.should eq(1)
+        expect(MongoUser.count).to eq(1)
         @doc.destroy
       end
 
       it "deletes the instance of MongoUser after save and then re-looking up the instance" do
         @doc.save
-        MongoUser.count.should eq(1)
+        expect(MongoUser.count).to eq(1)
         @doc = MongoUser.first
         @doc.destroy
       end
@@ -406,8 +404,8 @@ describe CarrierWave::Mongoid do
       @class.field :foo
       @doc = @class.new
       @doc.image = stub_file('old.jpeg')
-      @doc.save.should be_truthy
-      File.exists?(public_path('uploads/old.jpeg')).should be_truthy
+      expect(@doc.save).to be_truthy
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
     end
 
     after do
@@ -418,30 +416,30 @@ describe CarrierWave::Mongoid do
 
       it "should remove old file if old file had a different path" do
         @doc.image = stub_file('new.jpeg')
-        @doc.save.should be_truthy
-        File.exists?(public_path('uploads/new.jpeg')).should be_truthy
-        File.exists?(public_path('uploads/old.jpeg')).should be_falsey
+        expect(@doc.save).to be_truthy
+        expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_falsey
       end
 
       it "should not remove old file if old file had a different path but config is false" do
-        @uploader.stub(:remove_previously_stored_files_after_update).and_return(false)
+        allow(@uploader).to receive(:remove_previously_stored_files_after_update).and_return(false)
         @doc.image = stub_file('new.jpeg')
-        @doc.save.should be_truthy
-        File.exists?(public_path('uploads/new.jpeg')).should be_truthy
-        File.exists?(public_path('uploads/old.jpeg')).should be_truthy
+        expect(@doc.save).to be_truthy
+        expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
       end
 
       it "should not remove file if old file had the same path" do
         @doc.image = stub_file('old.jpeg')
-        @doc.save.should be_truthy
-        File.exists?(public_path('uploads/old.jpeg')).should be_truthy
+        expect(@doc.save).to be_truthy
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
       end
 
       it "should not remove file if validations fail on save" do
         @class.validate { |r| r.errors.add :textfile, "FAIL!" }
         @doc.image = stub_file('new.jpeg')
-        @doc.save.should be_falsey
-        File.exists?(public_path('uploads/old.jpeg')).should be_truthy
+        expect(@doc.save).to be_falsey
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
       end
     end
 
@@ -455,91 +453,91 @@ describe CarrierWave::Mongoid do
 
         @doc.image = stub_file('old.jpeg')
         @doc.foo = "test"
-        @doc.save.should be_truthy
-        File.exists?(public_path('uploads/test.jpeg')).should be_truthy
-        @doc.image.read.should == "this is stuff"
+        expect(@doc.save).to be_truthy
+        expect(File.exists?(public_path('uploads/test.jpeg'))).to be_truthy
+        expect(@doc.image.read).to eq "this is stuff"
       end
 
       it "should not remove file if old file had the same dynamic path" do
         @doc.image = stub_file('test.jpeg')
-        @doc.save.should be_truthy
-        File.exists?(public_path('uploads/test.jpeg')).should be_truthy
+        expect(@doc.save).to be_truthy
+        expect(File.exists?(public_path('uploads/test.jpeg'))).to be_truthy
       end
 
       it "should remove old file if old file had a different dynamic path" do
         @doc.foo = "new"
         @doc.image = stub_file('test.jpeg')
-        @doc.save.should be_truthy
-        File.exists?(public_path('uploads/new.jpeg')).should be_truthy
-        File.exists?(public_path('uploads/test.jpeg')).should be_falsey
+        expect(@doc.save).to be_truthy
+        expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy
+        expect(File.exists?(public_path('uploads/test.jpeg'))).to be_falsey
       end
     end
 
     shared_examples "embedded documents" do
       it "should remove old file if old file had a different path" do
         @embedded_doc.image = stub_file('new.jpeg')
-        @embedded_doc.save.should be_truthy
-        File.exists?(public_path('uploads/new.jpeg')).should be_truthy
-        File.exists?(public_path('uploads/old.jpeg')).should be_falsey
+        expect(@embedded_doc.save).to be_truthy
+        expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_falsey
       end
 
       it "should not remove old file if old file had a different path but config is false" do
-        @embedded_doc.image.stub(:remove_previously_stored_files_after_update).and_return(false)
+        allow(@embedded_doc.image).to receive(:remove_previously_stored_files_after_update).and_return(false)
         @embedded_doc.image = stub_file('new.jpeg')
-        @embedded_doc.save.should be_truthy
-        File.exists?(public_path('uploads/new.jpeg')).should be_truthy
-        File.exists?(public_path('uploads/old.jpeg')).should be_truthy
+        expect(@embedded_doc.save).to be_truthy
+        expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
       end
 
       it "should not remove file if old file had the same path" do
         @embedded_doc.image = stub_file('old.jpeg')
-        @embedded_doc.save.should be_truthy
-        File.exists?(public_path('uploads/old.jpeg')).should be_truthy
+        expect(@embedded_doc.save).to be_truthy
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
       end
 
       it "should not remove file if validations fail on save" do
         @embedded_doc_class.validate { |r| r.errors.add :textfile, "FAIL!" }
         @embedded_doc.image = stub_file('new.jpeg')
-        @embedded_doc.save.should be_falsey
-        File.exists?(public_path('uploads/old.jpeg')).should be_truthy
+        expect(@embedded_doc.save).to be_falsey
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
       end
 
       it "should not touch parent's dirty attributes" do
         @class.field :title
         @doc.title = "Title"
         @embedded_doc.image = stub_file('new.jpeg')
-        @embedded_doc.save.should be_truthy
-        @doc.title.should == "Title"
+        expect(@embedded_doc.save).to be_truthy
+        expect(@doc.title).to eq "Title"
       end
     end
 
     shared_examples "double embedded documents" do
       it "should remove old file if old file had a different path" do
         @double_embedded_doc.image = stub_file('new.jpeg')
-        @double_embedded_doc.save.should be_truthy
-        File.exists?(public_path('uploads/new.jpeg')).should be_truthy
-        File.exists?(public_path('uploads/old.jpeg')).should be_falsey
+        expect(@double_embedded_doc.save).to be_truthy
+        expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_falsey
       end
 
       it "should not remove old file if old file had a different path but config is false" do
-        @double_embedded_doc.image.stub(:remove_previously_stored_files_after_update).and_return(false)
+        allow(@double_embedded_doc.image).to receive(:remove_previously_stored_files_after_update).and_return(false)
         @double_embedded_doc.image = stub_file('new.jpeg')
-        @double_embedded_doc.save.should be_truthy
-        File.exists?(public_path('uploads/new.jpeg')).should be_truthy
-        File.exists?(public_path('uploads/old.jpeg')).should be_truthy
+        expect(@double_embedded_doc.save).to be_truthy
+        expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
       end
 
       it "should not remove file if old file had the same path" do
         @double_embedded_doc.image = stub_file('old.jpeg')
-        @double_embedded_doc.save.should be_truthy
-        File.exists?(public_path('uploads/old.jpeg')).should be_truthy
+        expect(@double_embedded_doc.save).to be_truthy
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
       end
 
       it "should not remove file if validations fail on save" do
         @double_embedded_doc_class.validate { |r| r.errors.add :textfile, "FAIL!" }
         @double_embedded_doc.image = stub_file('new.jpeg')
-        @double_embedded_doc.save.should be_falsey
-        File.exists?(public_path('uploads/old.jpeg')).should be_truthy
+        expect(@double_embedded_doc.save).to be_falsey
+        expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
       end
 
     end
@@ -559,7 +557,7 @@ describe CarrierWave::Mongoid do
         @doc = @class.new
         @embedded_doc = @doc.build_mongo_location
         @embedded_doc.image = stub_file('old.jpeg')
-        @embedded_doc.save.should be_truthy
+        expect(@embedded_doc.save).to be_truthy
       end
 
       include_examples "embedded documents"
@@ -581,7 +579,7 @@ describe CarrierWave::Mongoid do
         @doc = @class.new
         @embedded_doc = @doc.build_mongo_location
         @embedded_doc.image = stub_file('old.jpeg')
-        @embedded_doc.save.should be_truthy
+        expect(@embedded_doc.save).to be_truthy
       end
 
       include_examples "embedded documents"
@@ -603,7 +601,7 @@ describe CarrierWave::Mongoid do
         @doc = @class.new
         @embedded_doc = @doc.mongo_locations.build
         @embedded_doc.image = stub_file('old.jpeg')
-        @embedded_doc.save.should be_truthy
+        expect(@embedded_doc.save).to be_truthy
       end
 
       include_examples "embedded documents"
@@ -611,26 +609,26 @@ describe CarrierWave::Mongoid do
       it "attaches a new file to an existing document that had no file at first" do
         doc = @class.new
         doc.mongo_locations.build
-        doc.save.should be_truthy
+        expect(doc.save).to be_truthy
         doc.reload
 
         doc.mongo_locations.first.image = stub_file('test.jpeg')
-        doc.save.should be_truthy
+        expect(doc.save).to be_truthy
         doc.reload
 
-        doc.mongo_locations.first[:image].should == 'test.jpeg'
+        expect(doc.mongo_locations.first[:image]).to eq 'test.jpeg'
       end
 
       it "changes the file" do
         @doc.update_attributes mongo_locations_attributes: { '0' => { _id: @embedded_doc._id, image: stub_file('test.jpeg') } }
         @doc.reload
-        @doc.mongo_locations.first[:image].should == 'test.jpeg'
+        expect(@doc.mongo_locations.first[:image]).to eq 'test.jpeg'
       end
 
       it "removes a file" do
         @doc.update_attributes mongo_locations_attributes: { '0' => { _id: @embedded_doc._id, remove_image: "1" } }
         @doc.reload
-        @doc.mongo_locations.first[:image].should_not be_present
+        expect(@doc.mongo_locations.first[:image]).to_not be_present
       end
 
       describe 'with double embedded documents' do
@@ -649,11 +647,11 @@ describe CarrierWave::Mongoid do
           @doc = @class.new
           @embedded_doc = @doc.mongo_locations.build
           @embedded_doc.image = stub_file('old.jpeg')
-          @embedded_doc.save.should be_truthy
+          expect(@embedded_doc.save).to be_truthy
 
           @double_embedded_doc = @embedded_doc.mongo_items.build
           @double_embedded_doc.image = stub_file('old.jpeg')
-          @double_embedded_doc.save.should be_truthy
+          expect(@double_embedded_doc.save).to be_truthy
         end
 
         include_examples "double embedded documents"
@@ -676,7 +674,7 @@ describe CarrierWave::Mongoid do
         @doc = @class.new
         @embedded_doc = @doc.mongo_locations.build
         @embedded_doc.image = stub_file('old.jpeg')
-        @embedded_doc.save.should be_truthy
+        expect(@embedded_doc.save).to be_truthy
       end
 
       include_examples "embedded documents"
@@ -697,11 +695,11 @@ describe CarrierWave::Mongoid do
           @doc = @class.new
           @embedded_doc = @doc.mongo_locations.build
           @embedded_doc.image = stub_file('old.jpeg')
-          @embedded_doc.save.should be_truthy
+          expect(@embedded_doc.save).to be_truthy
 
           @double_embedded_doc = @embedded_doc.mongo_items.build
           @double_embedded_doc.image = stub_file('old.jpeg')
-          @double_embedded_doc.save.should be_truthy
+          expect(@double_embedded_doc.save).to be_truthy
         end
 
         include_examples "double embedded documents"
@@ -722,21 +720,21 @@ describe CarrierWave::Mongoid do
         end
 
         @doc = @class.new(mongo_locations_attributes: [{image: stub_file("old.jpeg")}])
-        @doc.save.should be_truthy
+        expect(@doc.save).to be_truthy
         @embedded_doc = @doc.mongo_locations.first
       end
 
       it "should set the image on a save" do
         @doc.reload
-        @doc.mongo_locations.first.image.path.should match(/old\.jpeg$/)
-        @embedded_doc.image.path.should match(/old\.jpeg$/)
+        expect(@doc.mongo_locations.first.image.path).to match(/old\.jpeg$/)
+        expect(@embedded_doc.image.path).to match(/old\.jpeg$/)
       end
 
       it "should update the image on update_attributes" do
-        @doc.update_attributes(mongo_locations_attributes: [{id: @embedded_doc.id, image: stub_file("new.jpeg")}]).should be_truthy
+        expect(@doc.update_attributes(mongo_locations_attributes: [{id: @embedded_doc.id, image: stub_file("new.jpeg")}])).to be_truthy
         @doc.reload
-        @doc.mongo_locations.first.image.path.should match(/new\.jpeg$/)
-        @embedded_doc.image.path.should match(/new\.jpeg$/)
+        expect(@doc.mongo_locations.first.image.path).to match(/new\.jpeg$/)
+        expect(@embedded_doc.image.path).to match(/new\.jpeg$/)
       end
     end
   end
@@ -749,9 +747,9 @@ describe CarrierWave::Mongoid do
       @class = reset_mongo_class(@uploader)
       @doc = @class.new
       @doc.image = stub_file('old.jpeg')
-      @doc.save.should be_truthy
-      File.exists?(public_path('uploads/old.jpeg')).should be_truthy
-      File.exists?(public_path('uploads/thumb_old.jpeg')).should be_truthy
+      expect(@doc.save).to be_truthy
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
+      expect(File.exists?(public_path('uploads/thumb_old.jpeg'))).to be_truthy
     end
 
     after do
@@ -760,18 +758,18 @@ describe CarrierWave::Mongoid do
 
     it "should remove old file if old file had a different path" do
       @doc.image = stub_file('new.jpeg')
-      @doc.save.should be_truthy
-      File.exists?(public_path('uploads/new.jpeg')).should be_truthy
-      File.exists?(public_path('uploads/thumb_new.jpeg')).should be_truthy
-      File.exists?(public_path('uploads/old.jpeg')).should be_falsey
-      File.exists?(public_path('uploads/thumb_old.jpeg')).should be_falsey
+      expect(@doc.save).to be_truthy
+      expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy
+      expect(File.exists?(public_path('uploads/thumb_new.jpeg'))).to be_truthy
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_falsey
+      expect(File.exists?(public_path('uploads/thumb_old.jpeg'))).to be_falsey
     end
 
     it "should not remove file if old file had the same path" do
       @doc.image = stub_file('old.jpeg')
-      @doc.save.should be_truthy
-      File.exists?(public_path('uploads/old.jpeg')).should be_truthy
-      File.exists?(public_path('uploads/thumb_old.jpeg')).should be_truthy
+      expect(@doc.save).to be_truthy
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
+      expect(File.exists?(public_path('uploads/thumb_old.jpeg'))).to be_truthy
     end
   end
 
@@ -785,9 +783,9 @@ describe CarrierWave::Mongoid do
       @doc = @class.new
       @doc.image = stub_file('old.jpeg')
       @doc.textfile = stub_file('old.txt')
-      @doc.save.should be_truthy
-      File.exists?(public_path('uploads/old.jpeg')).should be_truthy
-      File.exists?(public_path('uploads/old.txt')).should be_truthy
+      expect(@doc.save).to be_truthy
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
+      expect(File.exists?(public_path('uploads/old.txt'))).to be_truthy
     end
 
     after do
@@ -797,28 +795,28 @@ describe CarrierWave::Mongoid do
     it "should remove old file1 and file2 if old file1 and file2 had a different paths" do
       @doc.image = stub_file('new.jpeg')
       @doc.textfile = stub_file('new.txt')
-      @doc.save.should be_truthy
-      File.exists?(public_path('uploads/new.jpeg')).should be_truthy
-      File.exists?(public_path('uploads/old.jpeg')).should be_falsey
-      File.exists?(public_path('uploads/new.txt')).should be_truthy
-      File.exists?(public_path('uploads/old.txt')).should be_falsey
+      expect(@doc.save).to be_truthy
+      expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_falsey
+      expect(File.exists?(public_path('uploads/new.txt'))).to be_truthy
+      expect(File.exists?(public_path('uploads/old.txt'))).to be_falsey
     end
 
     it "should remove old file1 but not file2 if old file1 had a different path but old file2 has the same path" do
       @doc.image = stub_file('new.jpeg')
       @doc.textfile = stub_file('old.txt')
-      @doc.save.should be_truthy
-      File.exists?(public_path('uploads/new.jpeg')).should be_truthy
-      File.exists?(public_path('uploads/old.jpeg')).should be_falsey
-      File.exists?(public_path('uploads/old.txt')).should be_truthy
+      expect(@doc.save).to be_truthy
+      expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_falsey
+      expect(File.exists?(public_path('uploads/old.txt'))).to be_truthy
     end
 
     it "should not remove file1 or file2 if file1 and file2 have the same paths" do
       @doc.image = stub_file('old.jpeg')
       @doc.textfile = stub_file('old.txt')
-      @doc.save.should be_truthy
-      File.exists?(public_path('uploads/old.jpeg')).should be_truthy
-      File.exists?(public_path('uploads/old.txt')).should be_truthy
+      expect(@doc.save).to be_truthy
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
+      expect(File.exists?(public_path('uploads/old.txt'))).to be_truthy
     end
   end
 
@@ -830,8 +828,8 @@ describe CarrierWave::Mongoid do
       @class.mount_uploader(:avatar, @uploader1, :mount_on => :another_image)
       @doc = @class.new
       @doc.avatar = stub_file('old.jpeg')
-      @doc.save.should be_truthy
-      File.exists?(public_path('uploads/old.jpeg')).should be_truthy
+      expect(@doc.save).to be_truthy
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
     end
 
     after do
@@ -840,15 +838,15 @@ describe CarrierWave::Mongoid do
 
     it "should remove old file if old file had a different path" do
       @doc.avatar = stub_file('new.jpeg')
-      @doc.save.should be_truthy
-      File.exists?(public_path('uploads/new.jpeg')).should be_truthy
-      File.exists?(public_path('uploads/old.jpeg')).should be_falsey
+      expect(@doc.save).to be_truthy
+      expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_falsey
     end
 
     it "should not remove file if old file had the same path" do
       @doc.avatar = stub_file('old.jpeg')
-      @doc.save.should be_truthy
-      File.exists?(public_path('uploads/old.jpeg')).should be_truthy
+      expect(@doc.save).to be_truthy
+      expect(File.exists?(public_path('uploads/old.jpeg'))).to be_truthy
     end
   end
 
@@ -864,21 +862,21 @@ describe CarrierWave::Mongoid do
         end
 
         @doc = @class.new(image: stub_file("old.jpeg"))
-        @doc.save.should be_truthy
+        expect(@doc.save).to be_truthy
       end
 
       it "should not remove underlying image after #destroy" do
-        @doc.destroy.should be_truthy
-        @class.count.should eql(0)
-        @class.deleted.count.should eql(1)
-        File.exist?(public_path('uploads/old.jpeg')).should be_truthy
+        expect(@doc.destroy).to be_truthy
+        expect(@class.count).to eql(0)
+        expect(@class.deleted.count).to eql(1)
+        expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
       end
 
       it "should remove underlying image after #destroy!" do
-        @doc.destroy!.should be_truthy
-        @class.count.should eql(0)
-        @class.deleted.count.should eql(0)
-        File.exist?(public_path('uploads/old.jpeg')).should be_falsey
+        expect(@doc.destroy!).to be_truthy
+        expect(@class.count).to eql(0)
+        expect(@class.deleted.count).to eql(0)
+        expect(File.exist?(public_path('uploads/old.jpeg'))).to be_falsey
       end
     end
   end
@@ -893,14 +891,14 @@ describe CarrierWave::Mongoid do
     end
 
     it "serializes the correct values" do
-      @event.serializable_hash["image"]["url"].should match(/old\.jpeg$/)
-      @event.serializable_hash["textfile"]["url"].should match(/old\.txt$/)
+      expect(@event.serializable_hash["image"]["url"]).to match(/old\.jpeg$/)
+      expect(@event.serializable_hash["textfile"]["url"]).to match(/old\.txt$/)
     end
 
     it "should have JSON for each uploader" do
       parsed = JSON.parse(@event.to_json)
-      parsed["image"]["url"].should match(/old\.jpeg$/)
-      parsed["textfile"]["url"].should match(/old\.txt$/)
+      expect(parsed["image"]["url"]).to match(/old\.jpeg$/)
+      expect(parsed["textfile"]["url"]).to match(/old\.txt$/)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,8 +25,7 @@ module CarrierWave
   module Test
     module MockFiles
       def stub_file(filename, mime_type=nil, fake_name=nil)
-        f = File.open(file_path(filename))
-        return f
+        File.open(file_path(filename))
       end
 
       def stub_tempfile(filename, mime_type=nil, fake_name=nil)
@@ -35,9 +34,9 @@ module CarrierWave
         t = Tempfile.new(filename)
         FileUtils.copy_file(file_path(filename), t.path)
 
-        t.stub(:local_path => "",
-               :original_filename => filename || fake_name,
-               :content_type => mime_type)
+        allow(t).to receive(:local_path).and_return("")
+        allow(t).to receive(:original_filename).and_return(filename || fake_name)
+        allow(t).to receive(:content_type).and_return(mime_type)
 
         return t
       end
@@ -76,4 +75,5 @@ end
 RSpec.configure do |config|
   config.include CarrierWave::Test::MockFiles
   config.include CarrierWave::Test::I18nHelpers
+  config.color = true
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,10 @@ Mongoid.configure do |config|
   config.connect_to('carrierwave_test')
 end
 
+if defined? Mongo
+  Mongo::Logger.level = ::Logger::INFO
+end
+
 def file_path( *paths )
   File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', *paths))
 end

--- a/spec/storage/grid_fs_spec.rb
+++ b/spec/storage/grid_fs_spec.rb
@@ -1,51 +1,48 @@
 # encoding: utf-8
-
-
 require 'spec_helper'
-
 
 shared_examples_for "a GridFS connection" do
   describe '#store!' do
     before do
-      @uploader.stub(:store_path).and_return('uploads/bar.txt')
+      allow(@uploader).to receive(:store_path).and_return('uploads/bar.txt')
       @grid_fs_file = @storage.store!(@file)
     end
 
     it "should upload the file to gridfs" do
-      @grid['uploads/bar.txt'].data.should == 'this is stuff'
+      expect(@grid['uploads/bar.txt'].data).to eq 'this is stuff'
     end
 
     it "should upload the file to gridfs" do
-      @grid['uploads/bar.txt'].data.should == 'this is stuff'
+      expect(@grid['uploads/bar.txt'].data).to eq 'this is stuff'
     end
 
     it "should have the same path that it was stored as" do
-      @grid_fs_file.path.should == 'uploads/bar.txt'
+      expect(@grid_fs_file.path).to eq 'uploads/bar.txt'
     end
 
     it "should read the contents of the file" do
-      @grid_fs_file.read.should == "this is stuff"
+      expect(@grid_fs_file.read).to eq "this is stuff"
     end
 
     it "should not have a URL" do
-      @grid_fs_file.url.should be_nil
+      expect(@grid_fs_file.url).to be_nil
     end
 
     it "should be deletable" do
       @grid_fs_file.delete
-      @grid['uploads/bar.txt'].should be_nil
+      expect(@grid['uploads/bar.txt']).to be_nil
     end
 
     it "should store the content type on GridFS" do
-      @grid_fs_file.content_type.should == 'text/plain'
+      expect(@grid_fs_file.content_type).to eq 'text/plain'
     end
 
     it "should have a file length" do
-      @grid_fs_file.file_length.should == 13
+      expect(@grid_fs_file.file_length).to eq 13
     end
 
     it "should have a file md5" do
-      @grid_fs_file.md5.should == 'bf8456578232907ce3136ba776e1a40d'
+      expect(@grid_fs_file.md5).to eq 'bf8456578232907ce3136ba776e1a40d'
     end
   end
 
@@ -53,52 +50,52 @@ shared_examples_for "a GridFS connection" do
     before do
       @grid.clear
       @grid['uploads/bar.txt'] = StringIO.new('A test, 1234')
-      @uploader.stub(:store_path).with('bar.txt').and_return('uploads/bar.txt')
+      allow(@uploader).to receive(:store_path).with('bar.txt').and_return('uploads/bar.txt')
       @grid_fs_file = @storage.retrieve!('bar.txt')
     end
 
     it "should retrieve the file contents from gridfs" do
-      @grid_fs_file.read.chomp.should == "A test, 1234"
+      expect(@grid_fs_file.read.chomp).to eq "A test, 1234"
     end
 
     it "should have the same path that it was stored as" do
-      @grid_fs_file.path.should == 'uploads/bar.txt'
+      expect(@grid_fs_file.path).to eq 'uploads/bar.txt'
     end
 
     it "should not have a URL unless access_url is set" do
-      @grid_fs_file.url.should be_nil
+      expect(@grid_fs_file.url).to be_nil
     end
 
     it "should return a relative URL path if access_url is set to the root path" do
-      @uploader.stub(:grid_fs_access_url).and_return("/")
-      @grid_fs_file.url.should == "/uploads/bar.txt"
+      allow(@uploader).to receive(:grid_fs_access_url).and_return("/")
+      expect(@grid_fs_file.url).to eq "/uploads/bar.txt"
     end
 
     it "should return a URL path if access_url is set to a file path" do
-      @uploader.stub(:grid_fs_access_url).and_return("/image/show")
-      @grid_fs_file.url.should == "/image/show/uploads/bar.txt"
+      allow(@uploader).to receive(:grid_fs_access_url).and_return("/image/show")
+      expect(@grid_fs_file.url).to eq "/image/show/uploads/bar.txt"
     end
 
     it "should return an absolute URL if access_url is set to an absolute URL" do
-      @uploader.stub(:grid_fs_access_url).and_return("http://example.com/images/")
-      @grid_fs_file.url.should == "http://example.com/images/uploads/bar.txt"
+      allow(@uploader).to receive(:grid_fs_access_url).and_return("http://example.com/images/")
+      expect(@grid_fs_file.url).to eq "http://example.com/images/uploads/bar.txt"
     end
 
     it "should be deletable" do
       @grid_fs_file.delete
-      @grid['uploads/bar.txt'].should be_nil
+      expect(@grid['uploads/bar.txt']).to be_nil
     end
   end
 
   describe '#retrieve! on a store_dir with leading slash' do
     before do
-      @uploader.stub(:store_path).with('bar.txt').and_return('/uploads/bar.txt')
+      allow(@uploader).to receive(:store_path).with('bar.txt').and_return('/uploads/bar.txt')
       @grid_fs_file = @storage.retrieve!('bar.txt')
     end
 
     it "should return a relative URL path if access_url is set to the root path" do
-      @uploader.stub(:grid_fs_access_url).and_return("/")
-      @grid_fs_file.url.should == "/uploads/bar.txt"
+      allow(@uploader).to receive(:grid_fs_access_url).and_return("/")
+      expect(@grid_fs_file.url).to eq "/uploads/bar.txt"
     end
   end
 
@@ -108,12 +105,12 @@ describe CarrierWave::Storage::GridFS do
 
   before do
     @uploader = double('an uploader')
-    @uploader.stub(:grid_fs_access_url).and_return(nil)
+    allow(@uploader).to receive(:grid_fs_access_url).and_return(nil)
   end
 
   context "when reusing an existing connection manually" do
     before do
-      @uploader.stub(:grid_fs_connection).and_return(@database)
+      allow(@uploader).to receive(:grid_fs_connection).and_return(@database)
 
       @grid = ::Mongoid::GridFs
 
@@ -146,11 +143,8 @@ describe CarrierWave::Storage::GridFS do
       end
 
       it "recreates versions stored remotely without error" do
-        lambda {
-          @versioned.recreate_versions!
-        }.should_not raise_error
-
-        @versioned.should be_present
+        expect { @versioned.recreate_versions! }.not_to raise_error
+        expect(@versioned).to be_present
       end
     end
 
@@ -172,10 +166,7 @@ describe CarrierWave::Storage::GridFS do
       end
 
       it "resizes the file with out error" do
-        lambda {
-          @versioned.resize_to_fill(200, 200)
-        }.should_not raise_error
-
+        expect { @versioned.resize_to_fill(200, 200) }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
Updates dependencies on `RSpec` and `rake` to ease further development and maintenance. 

Hope this helps! 😸 

**Changes:**
- `rake` is bumped from v10 to v11
- `rspec` is bumped from v2 to v3
    - config moved from `Rakefile` to `spec_helper.rb`
    - `.should` syntax is deprecated, so we change to `expect().to`
    - `.stub` syntax is deprecated, so we change to `allow().to receive`
- ~~removes magic comment `# encoding: utf-8` since development will be Ruby 2+~~
- when `mongo-ruby-driver` is used, set logger to `info` instead of noisy `debug`