### PR TITLE
Test against carrierwave v0.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rvm:
 gemfile:
   - Gemfile
   - gemfiles/carrierwave-0.9.gemfile
+  - gemfiles/carrierwave-0.10.gemfile
   - gemfiles/carrierwave-master.gemfile
   - gemfiles/mongoid-3.1.gemfile
   - gemfiles/mongoid-4.0.gemfile

--- a/gemfiles/carrierwave-0.10.gemfile
+++ b/gemfiles/carrierwave-0.10.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "carrierwave", "~> 0.10.0"
+
+gemspec path: "../"


### PR DESCRIPTION
This gem is **green** when specs are run against the latest **carrierwave** published: `v0.11.2`.

@rmm5t stated in #158 that:
> We're not releasing an official version until we fully support the new features in carrierwave v0.11.0. Specifically `mount_uploaders`.

However, though `#mount_uploaders` is a feature on **carrierwave** `master`, [it still remains _unreleased_](https://github.com/carrierwaveuploader/carrierwave/blob/master/CHANGELOG.md#added) in the recently published versions of **carrierwave**, including `v0.11.0`.

I'm adding travis tests against **carrierwave** `~> v0.11.0` in this PR in the hopes that we can reconsider publishing a new version of **carrierwave-mongoid**, as is.

I apologize in advance if there is something here that I've misunderstood or am missing 😅. Beyond that, I'd love to lend a hand to get a passing build with parity to features in **carrierwave** `master`, especially `#mount_uploads`.

💛💚💙💜❤️