### PR TITLE
Mongoid 6.0 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ gemfile:
   - gemfiles/carrierwave-master.gemfile
   - gemfiles/mongoid-3.1.gemfile
   - gemfiles/mongoid-4.0.gemfile
+  - gemfiles/mongoid-5.0.gemfile
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,8 @@ matrix:
   allow_failures:
     - gemfile: gemfiles/carrierwave-master.gemfile
   fast_finish: true
+  include:
+    - rvm: 2.2.5
+      gemfile: gemfiles/mongoid-6.0.gemfile
+    - rvm: 2.3.1
+      gemfile: gemfiles/mongoid-6.0.gemfile

--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", [">= 0.8.0", "< 0.12.0"]
-  s.add_dependency "mongoid", [">= 3.0", "< 6.0"]
+  s.add_dependency "mongoid", [">= 3.0", "< 7.0"]
   s.add_dependency "mongoid-grid_fs", [">= 1.3", "< 3.0"]
   s.add_development_dependency "rspec", "~>3.4.0"
   s.add_development_dependency "rake", "~>11.1.2"

--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "carrierwave", [">= 0.8.0", "< 0.12.0"]
   s.add_dependency "mongoid", [">= 3.0", "< 7.0"]
   s.add_dependency "mongoid-grid_fs", [">= 1.3", "< 3.0"]
+  s.add_dependency "mime-types", "< 3" if RUBY_VERSION < "2.0" # mime-types 3+ doesn't support ruby 1.9
   s.add_development_dependency "rspec", "~>3.4.0"
   s.add_development_dependency "rake", "~>11.1.2"
   s.add_development_dependency "mini_magick"

--- a/gemfiles/mongoid-6.0.gemfile
+++ b/gemfiles/mongoid-6.0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "mongoid", "~> 6.0.0.beta"
+
+gemspec path: "../"


### PR DESCRIPTION
This adds Travis CI tests for mongoid 5.0 (previously unused) and mongoid 6.0. This also raises the mongoid version requirement.

Closes #164 