### PR TITLE
Fix broken _mounter(column.to_sym).uploader

### DIFF
--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -29,7 +29,7 @@ module CarrierWave
       after_save :"store_#{column}!"
       before_save :"write_#{column}_identifier"
       after_destroy :"remove_#{column}!"
-      before_update :"store_previous_model_for_#{column}"
+      before_update :"store_previous_changes_for_#{column}"
       after_save :"remove_previously_stored_#{column}"
 
       class_eval <<-RUBY, __FILE__, __LINE__+1

--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -97,7 +97,7 @@ module CarrierWave
 
           self.class.uploaders.each do |column, uploader|
             if (!only && !except) || (only && only.include?(column.to_s)) || (except && !except.include?(column.to_s))
-              hash[column.to_s] = _mounter(column.to_sym).uploader.serializable_hash
+              hash[column.to_s] = _mounter(column.to_sym).uploaders.map(&:serializable_hash)
             end
           end
           super(options).merge(hash)


### PR DESCRIPTION
I was getting an error when calling `as_json` on a model, which under the hood calls `serializable_hash`. I'm currently using the master version of carrierwave  specifically `carrierwave 0.11.0 from git://github.com/carrierwaveuploader/carrierwave.git (at master@8ceadb7)`.

```
Thing.last.serializable_hash
NoMethodError: undefined method `uploader' for #<CarrierWave::Mounter:0x007f8ac9e13b50>
Did you mean?  uploaders
    from <snip>/carrierwave-mongoid-0.10.0/lib/carrierwave/mongoid.rb:100:in `block in serializable_hash'
    from <snip>/carrierwave-mongoid-0.10.0/lib/carrierwave/mongoid.rb:98:in `each'
    from <snip>/carrierwave-mongoid-0.10.0/lib/carrierwave/mongoid.rb:98:in `serializable_hash'
    from (irb):4
```

I think what's happened is that carrierwave has added support for mount_uploaders (vs mount_uploader) that now supports an array of files, and under the hood changed a bunch of methods to support this. But I don't pretend to be an expert, just fixed my own version.

**NB: This pull request changes the resulting behaviour from `{"_id"=>..., "logo"=>{"url"=>"..."} }` to `{"_id"=>..., "logo"=>[{"url"=>"..."}] }`**
