### PR TITLE
Allow carrierwave 1.0.0.beta/1.0.0.rc dependency

### DIFF
--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "carrierwave", [">= 0.8.0", "< 0.12.0"]
+  s.add_dependency "carrierwave", [">= 0.8.0", "< 2.0"]
   s.add_dependency "mongoid", [">= 3.0", "< 7.0"]
   s.add_dependency "mongoid-grid_fs", [">= 1.3", "< 3.0"]
   s.add_dependency "mime-types", "< 3" if RUBY_VERSION < "2.0" # mime-types 3+ doesn't support ruby 1.9


### PR DESCRIPTION
Can this be merged to master so the edge version of `carrierwave` can be used?