### PR TITLE
Fix carrierwave 1.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ gemfile:
   - Gemfile
   - gemfiles/carrierwave-0.10.gemfile
   - gemfiles/carrierwave-0.11.gemfile
+  - gemfiles/carrierwave-1.0.gemfile
+  - gemfiles/carrierwave-1.1.gemfile
   - gemfiles/mongoid-3.1.gemfile
   - gemfiles/mongoid-4.0.gemfile
   - gemfiles/mongoid-5.0.gemfile

--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "carrierwave", [">= 0.8", "< 1.1"]
+  s.add_dependency "carrierwave", [">= 0.8", "< 1.2"]
   s.add_dependency "mongoid", [">= 3.0", "< 7.0"]
   s.add_dependency "mongoid-grid_fs", [">= 1.3", "< 3.0"]
   s.add_dependency "mime-types", "< 3" if RUBY_VERSION < "2.0" # mime-types 3+ doesn't support ruby 1.9

--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "carrierwave", [">= 0.8", "< 1.2"]
+  s.add_dependency "carrierwave", [">= 0.8", "< 1.3"]
   s.add_dependency "mongoid", [">= 3.0", "< 7.0"]
   s.add_dependency "mongoid-grid_fs", [">= 1.3", "< 3.0"]
   s.add_dependency "mime-types", "< 3" if RUBY_VERSION < "2.0" # mime-types 3+ doesn't support ruby 1.9

--- a/gemfiles/carrierwave-1.0.gemfile
+++ b/gemfiles/carrierwave-1.0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "carrierwave", "~> 1.0.0"
+
+gemspec path: "../"

--- a/gemfiles/carrierwave-1.1.gemfile
+++ b/gemfiles/carrierwave-1.1.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "carrierwave", "~> 1.1.0"
+
+gemspec path: "../"

--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -99,6 +99,14 @@ module CarrierWave
           end
         end
 
+        # CarrierWave 1.1 references ::ActiveRecord constant directly which
+        # will fail in projects without ActiveRecord. We need to overwrite this
+        # method to avoid it.
+        # See https://github.com/carrierwaveuploader/carrierwave/blob/07dc4d7bd7806ab4b963cf8acbad73d97cdfe74e/lib/carrierwave/mount.rb#L189
+        def store_previous_changes_for_#{column}
+          @_previous_changes_for_#{column} = changes[_mounter(:#{column}).serialization_column]
+        end
+
         def find_previous_model_for_#{column}
           if self.embedded?
             if self.respond_to?(:__metadata) # Mongoid >= 4.0.0.beta1

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -117,7 +117,7 @@ describe CarrierWave::Mongoid do
         @doc.save!
         @doc.reload
 
-        expect(JSON.parse({:data => @doc.image}.to_json)).to eq("data"=>{"image"=>{"url"=>"/uploads/test.jpeg"}})
+        expect(JSON.parse({:data => @doc.image}.to_json)).to eq("data"=>{"url"=>"/uploads/test.jpeg"})
       end
 
       it "should respect options[:only] when passed to to_json for the serializable hash" do
@@ -409,7 +409,7 @@ describe CarrierWave::Mongoid do
     end
 
     after do
-      FileUtils.rm_rf(file_path("uploads"))
+      FileUtils.rm_rf(public_path("uploads"))
     end
 
     describe 'normally' do
@@ -422,7 +422,7 @@ describe CarrierWave::Mongoid do
       end
 
       it "should not remove old file if old file had a different path but config is false" do
-        allow(@uploader).to receive(:remove_previously_stored_files_after_update).and_return(false)
+        @doc.image.class.remove_previously_stored_files_after_update = false
         @doc.image = stub_file('new.jpeg')
         expect(@doc.save).to be_truthy
         expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy
@@ -482,7 +482,7 @@ describe CarrierWave::Mongoid do
       end
 
       it "should not remove old file if old file had a different path but config is false" do
-        allow(@embedded_doc.image).to receive(:remove_previously_stored_files_after_update).and_return(false)
+        @embedded_doc.image.class.remove_previously_stored_files_after_update = false
         @embedded_doc.image = stub_file('new.jpeg')
         expect(@embedded_doc.save).to be_truthy
         expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy
@@ -520,7 +520,7 @@ describe CarrierWave::Mongoid do
       end
 
       it "should not remove old file if old file had a different path but config is false" do
-        allow(@double_embedded_doc.image).to receive(:remove_previously_stored_files_after_update).and_return(false)
+        @double_embedded_doc.image.class.remove_previously_stored_files_after_update = false
         @double_embedded_doc.image = stub_file('new.jpeg')
         expect(@double_embedded_doc.save).to be_truthy
         expect(File.exists?(public_path('uploads/new.jpeg'))).to be_truthy

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -117,7 +117,11 @@ describe CarrierWave::Mongoid do
         @doc.save!
         @doc.reload
 
-        expect(JSON.parse({:data => @doc.image}.to_json)).to eq("data"=>{"url"=>"/uploads/test.jpeg"})
+        if Gem::Version.new(CarrierWave::VERSION) >= Gem::Version.new("1.0.beta")
+          expect(JSON.parse({:data => @doc.image}.to_json)).to eq({"data"=>{"url"=>"/uploads/test.jpeg"}})
+        else
+          expect(JSON.parse({:data => @doc.image}.to_json)).to eq("data"=>{"image" => {"url"=>"/uploads/test.jpeg"}})
+        end
       end
 
       it "should respect options[:only] when passed to to_json for the serializable hash" do


### PR DESCRIPTION
This PR fixes all tests so that the gem can now support CarrierWave 1.0.

CarrierWave 1.0 changed the way it deals with replaced files (determining if the original file should be deleted) so I needed to overwrite `remove_previously_stored_#{column}` to support it. I also modified how we change `remove_previously_stored_files_after_update` config in tests to match the ActiveRecord equivalent. CarrierWave 1.0 checks this config on the uploader class, not instance.

The tests will fail for old versions of CarrierWave (`_mounter(column).uploader` vs `_mounter(column).uploaders`).

If there's anything I can help you with to get the CarrierWave 1.0 support out, let me know, I'll be happy to help.