### PR TITLE
Reset mounter cache on reload

### DIFF
--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -141,6 +141,12 @@ module CarrierWave
           end
           super(options).merge(hash)
         end
+
+        # Reset cached mounter on record reload
+        def reload
+          @_mounters = nil
+          super
+        end
       RUBY
     end
   end # Mongoid

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -139,6 +139,21 @@ describe CarrierWave::Mongoid do
         expect(JSON.parse(@doc.to_json({:except => [:_id, :image]}))).to eq("folder" => "")
       end
 
+      it "resets cached value on record reload" do
+        @doc[:image] = 'test.jpeg'
+        @doc.save!
+        @doc.reload
+
+        expect(JSON.parse(@doc.to_json)["image"]).to eq("url" => "/uploads/test.jpeg")
+
+        doc = @doc.class.find(@doc.id)
+        doc[:image] = nil
+        doc.save!
+
+        @doc.reload
+        expect(JSON.parse(@doc.to_json)["image"]).to eq("url" => nil)
+      end
+
     end
 
   end


### PR DESCRIPTION
`reload` should reflect updates to the upload from outside the current instance.

An identical patch was added for Active Record but never applied to Mongoid:

https://github.com/carrierwaveuploader/carrierwave/pull/1383