### PR TITLE
Fix README link to `cascade_callbacks` issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,4 +229,4 @@ class User
 end
 ```
 
-You can read more about this [here](https://github.com/carrierwaveuploader/carrierwave/issues#issue/81)
+You can read more about this [here](https://github.com/carrierwaveuploader/carrierwave/issues/81)


### PR DESCRIPTION
The link to https://github.com/carrierwaveuploader/carrierwave/issues/81 in the README is currently broken. This PR fixes that link.