### PR TITLE
Update mongoid dependency to < 9.0

### DIFF
--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", [">= 0.8", "< 3"]
-  s.add_dependency "mongoid", [">= 3.0", "< 8.0"]
+  s.add_dependency "mongoid", [">= 3.0", "< 9.0"]
   s.add_dependency "mongoid-grid_fs", [">= 1.3", "< 3.0"]
   s.add_dependency "mime-types", "< 3" if RUBY_VERSION < "2.0" # mime-types 3+ doesn't support ruby 1.9
   s.add_development_dependency "rspec", "~> 3.4"


### PR DESCRIPTION
Relate to this issue: https://github.com/carrierwaveuploader/carrierwave-mongoid/issues/203

## Issue ⚠️ 

Mongoid 8.0 is released with very important fixes and features, such as [this one](https://jira.mongodb.org/browse/MONGOID-5473).

However, the `carrierwave-mongoid` gem was resolved to 1.3.0, which depends on **mongoid (>= 3.0, < 8)**.


## Steps to Reproduce 👣 

* Gemfile
```rb
gem 'mongoid', '~> 8.0.2'
```

* CMD
```rb
bundle update mongoid
```

* Result
<img width="885" alt="Screen Shot 2022-09-30 at 04 15 34" src="https://user-images.githubusercontent.com/7637806/193213545-ce033f01-82b8-4158-ba6e-05911890f3ce.png">


## Solution 💡 

Could you guys make `carrierwave-mongoid` gem compatible with `mongoid > 8.0`?

Thanks!