### PR TITLE
Sr/make gridfs optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ Or, in Rails you can add it to your Gemfile:
 gem 'carrierwave-mongoid', :require => 'carrierwave/mongoid'
 ```
 
-Note: If using Rails 4, you'll need to make sure `mongoid-grid_fs` is `>= 1.9.0`.
-If in doubt, run `bundle update mongoid-grid_fs`
+Note: `mongoid-grid_fs` is no longer a runtime dependency. If you want to use
+GridFS storage, you'll need to make sure `mongoid-grid_fs` is in your Gemfile
+and uses version `>= 1.9.0`:
 
 ```ruby
-gem 'mongoid-grid_fs', github: 'ahoward/mongoid-grid_fs'
+gem 'mongoid-grid_fs', '>= 1.9.0'
 ```
 
 ## Getting Started
@@ -52,6 +53,10 @@ u.save!
 
 ## Using MongoDB's GridFS store
 
+Add `mongoid-grid_fs` to your Gemfile and
+
+    require 'carrierwave/storage/grid_fs'
+
 In your uploader, set the storage to `:grid_fs`:
 
 ```ruby
@@ -65,6 +70,8 @@ database connection and default all storage to GridFS. That might look something
 like this:
 
 ```ruby
+require 'carrierwave/storage/grid_fs'
+
 CarrierWave.configure do |config|
   config.storage = :grid_fs
   config.root = Rails.root.join('tmp')
@@ -151,6 +158,7 @@ match '/uploads/grid/user/avatar/:id/:filename' => 'gridfs#thumb_avatar', constr
 
 | Version   | Notes                                                                           |
 |-----------|---------------------------------------------------------------------------------|
+| ~> 2.0.0  | ([compare][compare-2.0], [dependencies][deps-2.0]) GridFS is now optional       |
 | ~> 1.1.0  | ([compare][compare-1.1], [dependencies][deps-1.1]) Mongoid 7.0 support          |
 | ~> 1.0.0  | ([compare][compare-1.0], [dependencies][deps-1.0]) Carrierwave 1.x support      |
 | ~> 0.10.0 | ([compare][compare-0.10], [dependencies][deps-0.10]) Mongoid 6.0  support       |
@@ -164,6 +172,7 @@ match '/uploads/grid/user/avatar/:id/:filename' => 'gridfs#thumb_avatar', constr
 | ~> 0.2.0  | ([compare][compare-0.2], [dependencies][deps-0.2]) Rails >= 3.2, Mongoid ~> 2.0 |
 | ~> 0.1.0  | ([compare][compare-0.1], [dependencies][deps-0.1]) Rails <= 3.1                 |
 
+[compare-2.0]: https://github.com/carrierwaveuploader/carrierwave-mongoid/compare/v1.3.0...v2.0.0
 [compare-1.1]: https://github.com/carrierwaveuploader/carrierwave-mongoid/compare/v1.0.0...v1.1.0
 [compare-1.0]: https://github.com/carrierwaveuploader/carrierwave-mongoid/compare/v0.10.0...v1.0.0
 [compare-0.10]: https://github.com/carrierwaveuploader/carrierwave-mongoid/compare/v0.9.0...v0.10.0
@@ -177,6 +186,7 @@ match '/uploads/grid/user/avatar/:id/:filename' => 'gridfs#thumb_avatar', constr
 [compare-0.2]: https://github.com/carrierwaveuploader/carrierwave-mongoid/compare/v0.1.7...v0.2.2
 [compare-0.1]: https://github.com/carrierwaveuploader/carrierwave-mongoid/compare/v0.1.1...v0.1.7
 
+[deps-1.1]: https://rubygems.org/gems/carrierwave-mongoid/versions/2.0.0
 [deps-1.1]: https://rubygems.org/gems/carrierwave-mongoid/versions/1.1.0
 [deps-1.0]: https://rubygems.org/gems/carrierwave-mongoid/versions/1.0.0
 [deps-0.10]: https://rubygems.org/gems/carrierwave-mongoid/versions/0.10.0

--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "carrierwave", [">= 0.8", "< 3"]
   s.add_dependency "mongoid", [">= 3.0", "< 8.0"]
-  s.add_dependency "mongoid-grid_fs", [">= 1.3", "< 3.0"]
   s.add_dependency "mime-types", "< 3" if RUBY_VERSION < "2.0" # mime-types 3+ doesn't support ruby 1.9
+  s.add_development_dependency "mongoid-grid_fs", [">= 1.3", "< 3.0"]
   s.add_development_dependency "rspec", "~>3.4.0"
   s.add_development_dependency "rake", "~>11.1.2"
   s.add_development_dependency "mini_magick"

--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -23,7 +23,9 @@ Gem::Specification.new do |s|
   s.add_dependency "carrierwave", [">= 0.8", "< 3"]
   s.add_dependency "mongoid", [">= 3.0", "< 8.0"]
   s.add_dependency "mime-types", "< 3" if RUBY_VERSION < "2.0" # mime-types 3+ doesn't support ruby 1.9
-  s.add_development_dependency "mongoid-grid_fs", [">= 1.3", "< 3.0"]
+  if ENV['WITH_GRIDFS'] == 'true'
+    s.add_development_dependency "mongoid-grid_fs", [">= 1.3", "< 3.0"]
+  end
   s.add_development_dependency "rspec", "~>3.4.0"
   s.add_development_dependency "rake", "~>11.1.2"
   s.add_development_dependency "mini_magick"

--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 require 'mongoid'
-require 'mongoid-grid_fs'
 require 'carrierwave'
 require 'carrierwave/validations/active_model'
 
@@ -145,15 +144,5 @@ module CarrierWave
     end
   end # Mongoid
 end # CarrierWave
-
-CarrierWave::Storage.autoload :GridFS, 'carrierwave/storage/grid_fs'
-
-class CarrierWave::Uploader::Base
-  add_config :grid_fs_access_url
-
-  configure do |config|
-    config.storage_engines[:grid_fs] = "CarrierWave::Storage::GridFS"
-  end
-end
 
 Mongoid::Document::ClassMethods.send(:include, CarrierWave::Mongoid)

--- a/lib/carrierwave/mongoid/version.rb
+++ b/lib/carrierwave/mongoid/version.rb
@@ -1,5 +1,5 @@
 module Carrierwave
   module Mongoid
-    VERSION = "1.3.0"
+    VERSION = "2.0.0"
   end
 end

--- a/lib/carrierwave/storage/grid_fs.rb
+++ b/lib/carrierwave/storage/grid_fs.rb
@@ -161,3 +161,11 @@ module CarrierWave
     end # GridFS
   end # Storage
 end # CarrierWave
+
+class CarrierWave::Uploader::Base
+  add_config :grid_fs_access_url
+
+  configure do |config|
+    config.storage_engines[:grid_fs] = "CarrierWave::Storage::GridFS"
+  end
+end

--- a/spec/storage/grid_fs_spec.rb
+++ b/spec/storage/grid_fs_spec.rb
@@ -103,6 +103,8 @@ end
 
 describe 'CarrierWave::Storage::GridFS' do
   before(:context) do
+    skip unless ENV['WITH_GRIDFS'] == 'true'
+
     require 'mongoid-grid_fs'
     require 'carrierwave/storage/grid_fs'
   end

--- a/spec/storage/grid_fs_spec.rb
+++ b/spec/storage/grid_fs_spec.rb
@@ -101,7 +101,11 @@ shared_examples_for "a GridFS connection" do
 
 end
 
-describe CarrierWave::Storage::GridFS do
+describe 'CarrierWave::Storage::GridFS' do
+  before(:context) do
+    require 'mongoid-grid_fs'
+    require 'carrierwave/storage/grid_fs'
+  end
 
   before do
     @uploader = double('an uploader')


### PR DESCRIPTION
As the `mongoid-grid_fs` gem is lagging a bit in allowing for mongoid 8, and we don't use the GridFS storage, this PR proposes to make the GridFS dependency optional. This had already been requested a few years back in #119 - maybe the sentiment regarding the dependency on GridFS has changed.

In order to make testing with and without GridFS as easier, the inclusion of mongoid-grid_fs can be controlled with an environment variable, both during `bundle install` and when running the specs.