### PR TITLE
Update build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         mongodb: [4.4]
-        ruby: [2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby: [2.7, 3.0, 3.1]
         gemfile:
           - carrierwave-2.1
           - carrierwave-2.2

--- a/gemfiles/mongoid-7.gemfile
+++ b/gemfiles/mongoid-7.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 gem "mongoid", "~> 7.0"
-gem "carrierwave", "~> 1.3"
+gem "carrierwave", "~> 2.2"
 
 gemspec path: "../"


### PR DESCRIPTION
## What does it do?

- Drops eol ruby versions from build matrix

## Related Issues

- Closes #208



 