### PR TITLE
Chore: bump mongoid 9 and support ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
           - carrierwave-2.2
           - mongoid-7
           - mongoid-8
+          - mongoid-9
         include:
           - { mongodb: "4.4", ruby: "2.6", gemfile: "carrierwave-0.10" }
           - { mongodb: "4.4", ruby: "2.6", gemfile: "carrierwave-0.11" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         mongodb: [4.4]
-        ruby: [2.7, "3.0", 3.1, 3.2]
+        ruby: [2.7, "3.0", 3.1, 3.2, 3.3]
         gemfile:
           - carrierwave-2.1
           - carrierwave-2.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: cat /home/runner/work/carrierwave-mongoid/carrierwave-mongoid/vendor/bundle/ruby/3.0.0/extensions/x86_64-linux/3.0.0/mimemagic-0.4.3/gem_make.out
+      - run: cat /home/runner/work/carrierwave-mongoid/carrierwave-mongoid/vendor/bundle/ruby/${{ matrix.ruby }}/extensions/x86_64-linux/${{ matrix.ruby }}/mimemagic-0.4.3/gem_make.out
         if: ${{ failure() }}
-      - run: cat /home/runner/work/carrierwave-mongoid/carrierwave-mongoid/vendor/bundle/ruby/3.0.0/gems/mimemagic-0.4.3/ext/mimemagic/Rakefile
+      - run: cat /home/runner/work/carrierwave-mongoid/carrierwave-mongoid/vendor/bundle/ruby/${{ matrix.ruby }}/gems/mimemagic-0.4.3/ext/mimemagic/Rakefile
         if: ${{ failure() }}
       - name: Run tests
         run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: supercharge/mongodb-github-action@1.3.0
         with:
           mongodb-version: ${{ matrix.mongodb }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "carrierwave", [">= 0.8", "< 3"]
-  s.add_dependency "mongoid", [">= 3.0", "< 9.0"]
+  s.add_dependency "mongoid", [">= 3.0", "< 10.0"]
   s.add_dependency "mongoid-grid_fs", [">= 1.3", "< 3.0"]
   s.add_dependency "mime-types", "< 3" if RUBY_VERSION < "2.0" # mime-types 3+ doesn't support ruby 1.9
   s.add_development_dependency "rspec", "~> 3.4"

--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
   s.add_dependency "mime-types", "< 3" if RUBY_VERSION < "2.0" # mime-types 3+ doesn't support ruby 1.9
   s.add_development_dependency "rspec", "~> 3.4"
   s.add_development_dependency "rake", ">= 12.3.3"
-  s.add_development_dependency "mini_magick"
+  s.add_development_dependency "mini_magick", "< 5"
   s.add_development_dependency "pry"
 end

--- a/gemfiles/mongoid-9.gemfile
+++ b/gemfiles/mongoid-9.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "mongoid", "~> 9.0"
+gem "carrierwave", "~> 2.2"
+
+gemspec path: "../"

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -623,11 +623,13 @@ describe CarrierWave::Mongoid do
 
       it "attaches a new file to an existing document that had no file at first" do
         doc = @class.new
-        doc.mongo_locations.build
+        new_file = doc.mongo_locations.build
+        expect(new_file.save).to be_truthy
         expect(doc.save).to be_truthy
         doc.reload
 
-        doc.mongo_locations.first.image = stub_file('test.jpeg')
+        new_file.image = stub_file('test.jpeg')
+        expect(new_file.save).to be_truthy
         expect(doc.save).to be_truthy
         doc.reload
 


### PR DESCRIPTION
~~This is draft, dependent on [mongoid-grid_fs](https://github.com/mongoid/mongoid-grid_fs) supporting [mongoid 9 ](https://github.com/mongoid/mongoid-grid_fs/pull/82)~~

This include a couple of updates, hopefully it's relevant:

- adds ruby 3.3 to test matrix
- bump mongoid dependency to <10
- tests were failing with mini_magick > 4 with carrierwave with calls to imagemagick `run_command` so I constrained it in the dev environment to < v5
- update the `cat` command in the ci workflow to use the ruby version used in matrix as the cat command was failing to run on failures. Probably need to check hardcoded `mimemagic-0.4.3` too
- update `actions/checkout` to v4 as v2 was logging errors about deprecated node 12

---

Fixes #213 