### PR TITLE
Support CarrierWave 3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
         mongodb: [4.4]
         ruby: [2.7, "3.0", 3.1, 3.2, 3.3]
         gemfile:
-          - carrierwave-2.1
           - carrierwave-2.2
+          - carrierwave-3.1
           - mongoid-7
           - mongoid-8
           - mongoid-9
@@ -20,6 +20,8 @@ jobs:
           - { mongodb: "4.4", ruby: "2.6", gemfile: "carrierwave-1.2" }
           - { mongodb: "4.4", ruby: "2.6", gemfile: "carrierwave-1.3" }
           - { mongodb: "4.4", ruby: "2.6", gemfile: "carrierwave-2.0" }
+          - { mongodb: "4.4", ruby: "2.6", gemfile: "carrierwave-2.1" }
+          - { mongodb: "4.4", ruby: "2.6", gemfile: "carrierwave-3.0" }
           - { mongodb: "4.4", ruby: "2.6", gemfile: "mongoid-3" }
           - { mongodb: "4.4", ruby: "2.6", gemfile: "mongoid-4" }
           - { mongodb: "4.4", ruby: "2.6", gemfile: "mongoid-5" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
         uses: supercharge/mongodb-github-action@1.3.0
         with:
           mongodb-version: ${{ matrix.mongodb }}
+      - name: Install ImageMagick
+        run: sudo apt-get -y install imagemagick
       - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ pkg/*
 *.sw*
 .bundle
 spec/public
+spec/tmp
 .rvmrc
 .ruby-version
 Gemfile.lock

--- a/carrierwave-mongoid.gemspec
+++ b/carrierwave-mongoid.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "carrierwave", [">= 0.8", "< 3"]
+  s.add_dependency "carrierwave", [">= 0.8", "< 4"]
   s.add_dependency "mongoid", [">= 3.0", "< 10.0"]
   s.add_dependency "mongoid-grid_fs", [">= 1.3", "< 3.0"]
   s.add_dependency "mime-types", "< 3" if RUBY_VERSION < "2.0" # mime-types 3+ doesn't support ruby 1.9

--- a/gemfiles/carrierwave-3.0.gemfile
+++ b/gemfiles/carrierwave-3.0.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "carrierwave", "~> 3.0.0"
+
+gemspec path: "../"

--- a/gemfiles/carrierwave-3.1.gemfile
+++ b/gemfiles/carrierwave-3.1.gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "carrierwave", "~> 3.1.0"
+
+gemspec path: "../"

--- a/lib/carrierwave/mongoid.rb
+++ b/lib/carrierwave/mongoid.rb
@@ -8,155 +8,23 @@ require 'carrierwave/validations/active_model'
 module CarrierWave
   module Mongoid
     include CarrierWave::Mount
-    ##
-    # See +CarrierWave::Mount#mount_uploader+ for documentation
-    #
-    def mount_uploader(column, uploader=nil, options={}, &block)
-      field options[:mount_on] || column
 
-      super
+    module CarrierWave3
+      def mount_uploader(column, uploader=nil, options={}, &block)
+        field options[:mount_on] || column
 
-      alias_method :read_uploader, :read_attribute
-      alias_method :write_uploader, :write_attribute
-      public :read_uploader
-      public :write_uploader
-
-      include CarrierWave::Validations::ActiveModel
-
-      validates_integrity_of  column if uploader_option(column.to_sym, :validate_integrity)
-      validates_processing_of column if uploader_option(column.to_sym, :validate_processing)
-
-      after_save :"store_#{column}!"
-      before_save :"write_#{column}_identifier"
-      after_destroy :"remove_#{column}!"
-      if Gem::Version.new(CarrierWave::VERSION) >= Gem::Version.new("1.0.beta")
-        before_update :"store_previous_changes_for_#{column}"
-      else
-        before_update :"store_previous_model_for_#{column}"
+        super
       end
-      after_save :"remove_previously_stored_#{column}"
 
-      class_eval <<-RUBY, __FILE__, __LINE__+1
-        def #{column}=(new_file)
-          column = _mounter(:#{column}).serialization_column
-
-          # We're using _new_ and _old_ placeholder values to force Mongoid to
-          # recognize changes in embedded documents. Before we assign these
-          # values, we need to store the original file name in case we need to
-          # delete it when document is saved.
-          previous_uploader_value = read_uploader(column)
-          @_previous_uploader_value_for_#{column} = previous_uploader_value
-
-          # mongoid won't upload a new file if there was no file previously.
-          write_uploader(column, '_old_') if self.persisted? && read_uploader(column).nil?
-
-          send(:"\#{column}_will_change!")
-          super
-        end
-
-        def remove_#{column}=(arg)
-          if ['1', true].include?(arg)
-            column = _mounter(:#{column}).serialization_column
-            send(:"\#{column}_will_change!")
-          end
-          super
-        end
-
-        def remove_#{column}!
-          super unless respond_to?(:paranoid?) && paranoid? && flagged_for_destroy?
-        end
-
-        # Overrides Mongoid's default dirty behavior to instead work more like
-        # ActiveRecord's. Mongoid doesn't deem an attribute as changed unless
-        # the new value is different than the original. Given that CarrierWave
-        # caches files before save, it's necessary to know that there's a
-        # pending change even though the attribute value itself might not
-        # reflect that yet.
-        def #{column}_changed?
-          changed_attributes.has_key?("#{column}")
-        end
-
-        # The default Mongoid attribute_will_change! method is not enough
-        # when we want to upload a new file in an existing embedded document.
-        # The custom version of that method forces the callbacks to be
-        # ran and so does the upload.
-        def #{column}_will_change!
-          changed_attributes["#{column}"] = '_new_'
-        end
-
-        # Since we had to use tricks with _old_ and _new_ values to properly
-        # track changes in embedded documents, we need to overwrite this method
-        # to remove the original file if it was replaced with a new one that
-        # had a different name.
-        if Gem::Version.new(CarrierWave::VERSION) >= Gem::Version.new("1.0.beta")
-          def remove_previously_stored_#{column}
-            before, after = @_previous_changes_for_#{column}
-            # Don't delete if the files had the same name
-            return if before.nil? && after.nil?
-            # Proceed to remove the file, use the original name instead of '_new_'
-            before = @_previous_uploader_value_for_#{column} || before
-            _mounter(:#{column}).remove_previous([before], [after])
-          end
-        end
-
-        # CarrierWave 1.1 references ::ActiveRecord constant directly which
-        # will fail in projects without ActiveRecord. We need to overwrite this
-        # method to avoid it.
-        # See https://github.com/carrierwaveuploader/carrierwave/blob/07dc4d7bd7806ab4b963cf8acbad73d97cdfe74e/lib/carrierwave/mount.rb#L189
-        def store_previous_changes_for_#{column}
-          @_previous_changes_for_#{column} = changes[_mounter(:#{column}).serialization_column]
-        end
-
-        def find_previous_model_for_#{column}
-          if self.embedded?
-            ancestors =
-              if self.respond_to?(:_association) # Mongoid >= 7.0.0.beta
-                [[ self._association.key, self._parent ]].tap { |x| x.unshift([ x.first.last._association.key, x.first.last._parent ]) while x.first.last.embedded? }
-              elsif self.respond_to?(:__metadata) # Mongoid >= 4.0.0.beta1 < 7.0.0.beta
-                [[ self.__metadata.key, self._parent ]].tap { |x| x.unshift([ x.first.last.__metadata.key, x.first.last._parent ]) while x.first.last.embedded? }
-              else # Mongoid < 4.0.0.beta1
-                [[ self.metadata.key, self._parent ]].tap { |x| x.unshift([ x.first.last.metadata.key, x.first.last._parent ]) while x.first.last.embedded? }
-              end
-            first_parent = ancestors.first.last
-            reloaded_parent = first_parent.class.unscoped.find(first_parent.to_key.first)
-            association = ancestors.inject(reloaded_parent) { |parent,(key,ancestor)| (parent.is_a?(Array) ? parent.find(ancestor.to_key.first) : parent).send(key) }
-            association.is_a?(Array) ? association.find(to_key.first) : association
-          else
-            self.class.unscoped.for_ids(to_key).first
-          end
-        end
-
-        def serializable_hash(options=nil)
-          hash = {}
-
-          except = options && options[:except] && Array.wrap(options[:except]).map(&:to_s)
-          only   = options && options[:only]   && Array.wrap(options[:only]).map(&:to_s)
-
-          self.class.uploaders.each do |column, uploader|
-            if (!only && !except) || (only && only.include?(column.to_s)) || (except && !except.include?(column.to_s))
-              if Gem::Version.new(CarrierWave::VERSION) >= Gem::Version.new("1.0.beta")
-                next if _mounter(column.to_sym).uploaders.blank?
-                hash[column.to_s] = _mounter(column.to_sym).uploaders[0].serializable_hash
-              else
-                hash[column.to_s] = _mounter(column.to_sym).uploader.serializable_hash
-              end
-            end
-          end
-          super(options).merge(hash)
-        end
-
-        # Reset cached mounter on mongoid reload
-        def reload
-          @_mounters = nil
-          super
-        end
-      RUBY
-    end
-
-    if Gem::Version.new(CarrierWave::VERSION) >= Gem::Version.new('1.0.beta')
       def mount_uploaders(column, uploader = nil, options = {}, &block)
         field (options[:mount_on] || column), type: Array, default: []
 
+        super
+      end
+
+    private
+
+      def mount_base(column, uploader=nil, options={}, &block)
         super
 
         alias_method :read_uploader, :read_attribute
@@ -168,39 +36,124 @@ module CarrierWave
 
         validates_integrity_of column if uploader_option(column.to_sym, :validate_integrity)
         validates_processing_of column if uploader_option(column.to_sym, :validate_processing)
+        validates_download_of column if uploader_option(column.to_sym, :validate_download)
 
-        before_update :"store_previous_changes_for_#{column}"
-        before_save :"write_#{column}_identifier"
         after_save :"store_#{column}!"
-        after_save :"remove_previously_stored_#{column}"
+        before_save :"write_#{column}_identifier"
+        after_update :"remove_previously_stored_#{column}"
+        after_save :"reset_previous_changes_for_#{column}"
+        after_update :"mark_remove_#{column}_false"
         after_destroy :"remove_#{column}!"
 
-        class_eval <<-RUBY, __FILE__, (__LINE__ + 1)
-          def #{column}=(new_files)
+        mod = Module.new
+        prepend mod
+        mod.class_eval <<-RUBY, __FILE__, __LINE__+1
+        def serializable_hash(options=nil)
+          hash = {}
+
+          except = options && options[:except] && Array.wrap(options[:except]).map(&:to_s)
+          only   = options && options[:only]   && Array.wrap(options[:only]).map(&:to_s)
+
+          self.class.uploaders.each do |column, uploader|
+            if (!only && !except) || (only && only.include?(column.to_s)) || (except && !except.include?(column.to_s))
+              next if _mounter(column.to_sym).uploaders.blank?
+              hash[column.to_s] = _mounter(column.to_sym).#{options[:multiple] ? "uploaders.map(&:serializable_hash)" : "uploaders[0].serializable_hash"}
+            end
+          end
+          super(options).merge(hash)
+        end
+
+        # Reset cached mounter on record reload
+        def reload(*)
+          @_mounters = nil
+          super
+        end
+
+        # Reset cached mounter on record dup
+        def initialize_dup(other)
+          old_uploaders = _mounter(:"#{column}").uploaders
+          super
+          @_mounters[:"#{column}"] = nil
+          # The attribute needs to be cleared to prevent it from picked up as identifier
+          write_attribute(_mounter(:#{column}).serialization_column, nil)
+          _mounter(:"#{column}").cache(old_uploaders)
+        end
+
+        def write_#{column}_identifier
+          return unless has_attribute?(_mounter(:#{column}).serialization_column)
+          super
+        end
+      RUBY
+      end
+    end
+
+    module CarrierWavePre3
+      ##
+      # See +CarrierWave::Mount#mount_uploader+ for documentation
+      #
+      def mount_uploader(column, uploader=nil, options={}, &block)
+        field options[:mount_on] || column
+
+        super
+
+        alias_method :read_uploader, :read_attribute
+        alias_method :write_uploader, :write_attribute
+        public :read_uploader
+        public :write_uploader
+
+        include CarrierWave::Validations::ActiveModel
+
+        validates_integrity_of  column if uploader_option(column.to_sym, :validate_integrity)
+        validates_processing_of column if uploader_option(column.to_sym, :validate_processing)
+
+        after_save :"store_#{column}!"
+        before_save :"write_#{column}_identifier"
+        after_destroy :"remove_#{column}!"
+        if Gem::Version.new(CarrierWave::VERSION) >= Gem::Version.new("1.0.beta")
+          before_update :"store_previous_changes_for_#{column}"
+        else
+          before_update :"store_previous_model_for_#{column}"
+        end
+        after_save :"remove_previously_stored_#{column}"
+
+        class_eval <<-RUBY, __FILE__, __LINE__+1
+          def #{column}=(new_file)
             column = _mounter(:#{column}).serialization_column
-  
+
+            # We're using _new_ and _old_ placeholder values to force Mongoid to
+            # recognize changes in embedded documents. Before we assign these
+            # values, we need to store the original file name in case we need to
+            # delete it when document is saved.
             previous_uploader_value = read_uploader(column)
             @_previous_uploader_value_for_#{column} = previous_uploader_value
-  
-            write_uploader(column, []) if self.persisted? && read_uploader(column).nil?
-  
-            send(:"\#{column}_will_change!")
 
+            # mongoid won't upload a new file if there was no file previously.
+            write_uploader(column, '_old_') if self.persisted? && read_uploader(column).nil?
+
+            send(:"\#{column}_will_change!")
             super
           end
 
-          def #{column}_changed?
-            changed_attributes.has_key?("#{column}")
-          end
-
-          def remove_#{column}=(value)
-            if ['1', true].include?(value)
+          def remove_#{column}=(arg)
+            if ['1', true].include?(arg)
               column = _mounter(:#{column}).serialization_column
-
               send(:"\#{column}_will_change!")
             end
-
             super
+          end
+
+          def remove_#{column}!
+            super unless respond_to?(:paranoid?) && paranoid? && flagged_for_destroy?
+          end
+
+          # Overrides Mongoid's default dirty behavior to instead work more like
+          # ActiveRecord's. Mongoid doesn't deem an attribute as changed unless
+          # the new value is different than the original. Given that CarrierWave
+          # caches files before save, it's necessary to know that there's a
+          # pending change even though the attribute value itself might not
+          # reflect that yet.
+          def #{column}_changed?
+            changed_attributes.has_key?("#{column}")
           end
 
           # The default Mongoid attribute_will_change! method is not enough
@@ -208,39 +161,173 @@ module CarrierWave
           # The custom version of that method forces the callbacks to be
           # ran and so does the upload.
           def #{column}_will_change!
-            changed_attributes["#{column}"] = ['_new_']
+            changed_attributes["#{column}"] = '_new_'
           end
 
-          def remove_previously_stored_#{column}
-            before, after = @_previous_changes_for_#{column}
-            # Don't delete if the files had the same name
-            return if before.nil? && after.nil?
-            # Proceed to remove the file, use the original name instead of '_new_'
-            before = @_previous_uploader_value_for_#{column} || before
-            _mounter(:#{column}).remove_previous(Array.wrap(before), Array.wrap(after))
-          end
-
-          def serializable_hash(options = nil)
-            hash = {}
-  
-            except = options && options[:except] && Array.wrap(options[:except]).map(&:to_s)
-            only = options && options[:only] && Array.wrap(options[:only]).map(&:to_s)
-  
-            self.class.uploaders.each do |column, _uploader|
-              if (!only && !except) || (only && only.include?(column.to_s)) || (except && !except.include?(column.to_s))
-                next if _mounter(column.to_sym).uploaders.blank?
-                hash[column.to_s] = _mounter(column.to_sym).uploaders.map(&:serializable_hash)
-              end
+          # Since we had to use tricks with _old_ and _new_ values to properly
+          # track changes in embedded documents, we need to overwrite this method
+          # to remove the original file if it was replaced with a new one that
+          # had a different name.
+          if Gem::Version.new(CarrierWave::VERSION) >= Gem::Version.new("1.0.beta")
+            def remove_previously_stored_#{column}
+              before, after = @_previous_changes_for_#{column}
+              # Don't delete if the files had the same name
+              return if before.nil? && after.nil?
+              # Proceed to remove the file, use the original name instead of '_new_'
+              before = @_previous_uploader_value_for_#{column} || before
+              _mounter(:#{column}).remove_previous([before], [after])
             end
-
-            super(options).merge(hash)
           end
 
+          # CarrierWave 1.1 references ::ActiveRecord constant directly which
+          # will fail in projects without ActiveRecord. We need to overwrite this
+          # method to avoid it.
+          # See https://github.com/carrierwaveuploader/carrierwave/blob/07dc4d7bd7806ab4b963cf8acbad73d97cdfe74e/lib/carrierwave/mount.rb#L189
           def store_previous_changes_for_#{column}
             @_previous_changes_for_#{column} = changes[_mounter(:#{column}).serialization_column]
           end
+
+          def find_previous_model_for_#{column}
+            if self.embedded?
+              ancestors =
+                if self.respond_to?(:_association) # Mongoid >= 7.0.0.beta
+                  [[ self._association.key, self._parent ]].tap { |x| x.unshift([ x.first.last._association.key, x.first.last._parent ]) while x.first.last.embedded? }
+                elsif self.respond_to?(:__metadata) # Mongoid >= 4.0.0.beta1 < 7.0.0.beta
+                  [[ self.__metadata.key, self._parent ]].tap { |x| x.unshift([ x.first.last.__metadata.key, x.first.last._parent ]) while x.first.last.embedded? }
+                else # Mongoid < 4.0.0.beta1
+                  [[ self.metadata.key, self._parent ]].tap { |x| x.unshift([ x.first.last.metadata.key, x.first.last._parent ]) while x.first.last.embedded? }
+                end
+              first_parent = ancestors.first.last
+              reloaded_parent = first_parent.class.unscoped.find(first_parent.to_key.first)
+              association = ancestors.inject(reloaded_parent) { |parent,(key,ancestor)| (parent.is_a?(Array) ? parent.find(ancestor.to_key.first) : parent).send(key) }
+              association.is_a?(Array) ? association.find(to_key.first) : association
+            else
+              self.class.unscoped.for_ids(to_key).first
+            end
+          end
+
+          def serializable_hash(options=nil)
+            hash = {}
+
+            except = options && options[:except] && Array.wrap(options[:except]).map(&:to_s)
+            only   = options && options[:only]   && Array.wrap(options[:only]).map(&:to_s)
+
+            self.class.uploaders.each do |column, uploader|
+              if (!only && !except) || (only && only.include?(column.to_s)) || (except && !except.include?(column.to_s))
+                if Gem::Version.new(CarrierWave::VERSION) >= Gem::Version.new("1.0.beta")
+                  next if _mounter(column.to_sym).uploaders.blank?
+                  hash[column.to_s] = _mounter(column.to_sym).uploaders[0].serializable_hash
+                else
+                  hash[column.to_s] = _mounter(column.to_sym).uploader.serializable_hash
+                end
+              end
+            end
+            super(options).merge(hash)
+          end
+
+          # Reset cached mounter on mongoid reload
+          def reload
+            @_mounters = nil
+            super
+          end
         RUBY
       end
+
+      if Gem::Version.new(CarrierWave::VERSION) >= Gem::Version.new('1.0.beta')
+        def mount_uploaders(column, uploader = nil, options = {}, &block)
+          field (options[:mount_on] || column), type: Array, default: []
+
+          super
+
+          alias_method :read_uploader, :read_attribute
+          alias_method :write_uploader, :write_attribute
+          public :read_uploader
+          public :write_uploader
+
+          include CarrierWave::Validations::ActiveModel
+
+          validates_integrity_of column if uploader_option(column.to_sym, :validate_integrity)
+          validates_processing_of column if uploader_option(column.to_sym, :validate_processing)
+
+          before_update :"store_previous_changes_for_#{column}"
+          before_save :"write_#{column}_identifier"
+          after_save :"store_#{column}!"
+          after_save :"remove_previously_stored_#{column}"
+          after_destroy :"remove_#{column}!"
+
+          class_eval <<-RUBY, __FILE__, (__LINE__ + 1)
+            def #{column}=(new_files)
+              column = _mounter(:#{column}).serialization_column
+
+              previous_uploader_value = read_uploader(column)
+              @_previous_uploader_value_for_#{column} = previous_uploader_value
+
+              write_uploader(column, []) if self.persisted? && read_uploader(column).nil?
+
+              send(:"\#{column}_will_change!")
+
+              super
+            end
+
+            def #{column}_changed?
+              changed_attributes.has_key?("#{column}")
+            end
+
+            def remove_#{column}=(value)
+              if ['1', true].include?(value)
+                column = _mounter(:#{column}).serialization_column
+
+                send(:"\#{column}_will_change!")
+              end
+
+              super
+            end
+
+            # The default Mongoid attribute_will_change! method is not enough
+            # when we want to upload a new file in an existing embedded document.
+            # The custom version of that method forces the callbacks to be
+            # ran and so does the upload.
+            def #{column}_will_change!
+              changed_attributes["#{column}"] = ['_new_']
+            end
+
+            def remove_previously_stored_#{column}
+              before, after = @_previous_changes_for_#{column}
+              # Don't delete if the files had the same name
+              return if before.nil? && after.nil?
+              # Proceed to remove the file, use the original name instead of '_new_'
+              before = @_previous_uploader_value_for_#{column} || before
+              _mounter(:#{column}).remove_previous(Array.wrap(before), Array.wrap(after))
+            end
+
+            def serializable_hash(options = nil)
+              hash = {}
+
+              except = options && options[:except] && Array.wrap(options[:except]).map(&:to_s)
+              only = options && options[:only] && Array.wrap(options[:only]).map(&:to_s)
+
+              self.class.uploaders.each do |column, _uploader|
+                if (!only && !except) || (only && only.include?(column.to_s)) || (except && !except.include?(column.to_s))
+                  next if _mounter(column.to_sym).uploaders.blank?
+                  hash[column.to_s] = _mounter(column.to_sym).uploaders.map(&:serializable_hash)
+                end
+              end
+
+              super(options).merge(hash)
+            end
+
+            def store_previous_changes_for_#{column}
+              @_previous_changes_for_#{column} = changes[_mounter(:#{column}).serialization_column]
+            end
+          RUBY
+        end
+      end
+    end
+
+    if Gem::Version.new(CarrierWave::VERSION) >= Gem::Version.new("3.0.beta")
+      include CarrierWave3
+    else
+      include CarrierWavePre3
     end
   end # Mongoid
 end # CarrierWave
@@ -253,6 +340,26 @@ class CarrierWave::Uploader::Base
   configure do |config|
     config.storage_engines[:grid_fs] = "CarrierWave::Storage::GridFS"
   end
+end
+
+if Gem::Version.new("3.0.beta") <= Gem::Version.new(CarrierWave::VERSION) &&
+  Gem::Version.new(CarrierWave::VERSION) < Gem::Version.new("3.1.1")
+  # Monkey patch to work around https://github.com/carrierwaveuploader/carrierwave/issues/2770
+  CarrierWave::SanitizedFile.prepend Module.new {
+    def read(*args)
+      if args.empty?
+        super
+      else
+        if is_path?
+          @file = File.open(path, "rb")
+        elsif @file.is_a?(CarrierWave::Uploader::Base)
+          @file = StringIO.new(@file.read)
+        end
+
+        @file.read(*args)
+      end
+    end
+  }
 end
 
 Mongoid::Document::ClassMethods.send(:include, CarrierWave::Mongoid)

--- a/spec/carrierwave/mongoid/mount_uploaders_spec.rb
+++ b/spec/carrierwave/mongoid/mount_uploaders_spec.rb
@@ -240,10 +240,6 @@ describe CarrierWave::Mongoid do
                 expect(model.images.map(&:identifier)).to match_array(identifiers)
               end
 
-              it 'does not write anything to the database, in order to prevent overridden filenames to fail because of unassigned attributes' do
-                expect(model[:images]).to match_array([])
-              end
-
               it 'copies a file into into the cache directory' do
                 expect(model.images.first.current_path).to match(/^#{Regexp.escape(public_path('uploads/tmp'))}/)
               end
@@ -259,10 +255,6 @@ describe CarrierWave::Mongoid do
               it 'caches the file' do
                 expect(model.images).to all(be_an_instance_of(uploader_class))
                 expect(model.images.map(&:identifier)).to match_array(['portrait.jpg', 'test.jpeg'])
-              end
-
-              it 'does not write anything to the database, in order to prevent overridden filenames to fail because of unassigned attributes' do
-                expect(model[:images]).to match_array(['portrait.jpg'])
               end
 
               it 'copies a file into into the cache directory' do
@@ -300,10 +292,6 @@ describe CarrierWave::Mongoid do
           it 'caches the files' do
             expect(model.images.count).to be files.count
             expect(model.images).to all(be_an_instance_of(uploader_class))
-          end
-
-          it 'does not write to the database' do
-            expect(model[:images]).to be_empty
           end
 
           it 'copies a file into into the cache directory' do

--- a/spec/carrierwave/mongoid/mount_uploaders_spec.rb
+++ b/spec/carrierwave/mongoid/mount_uploaders_spec.rb
@@ -497,10 +497,10 @@ describe CarrierWave::Mongoid do
             uploader_class.remove_previously_stored_files_after_update = true
           end
 
-          it 'does not remove file if old file had the same path' do
+          it 'does not remove new file if both of files had the same path' do
             model.images = [stub_file('old.jpeg')]
             expect(model.save).to be_truthy
-            expect(File).to exist(public_path('uploads/old.jpeg'))
+            expect(File).to exist(model.images[0].path)
           end
 
           it 'does not remove file if validations fail on save' do
@@ -522,13 +522,13 @@ describe CarrierWave::Mongoid do
 
           let!(:model) { model_class.create!(name: 'Mike', images: [stub_file('old.jpeg')]) }
 
-          it 'does not remove file if old file had the same dynamic path' do
+          it 'does not remove new file if both of files had the same path' do
             expect(File).to exist(public_path('uploads/Mike.jpeg'))
             expect(model.images.first.read).to eq 'this is stuff'
 
             model.update!(images: [stub_file('test.jpeg')])
 
-            expect(File).to exist(public_path('uploads/Mike.jpeg'))
+            expect(File).to exist(model.images[0].path)
           end
 
           it 'removes old file if old file had a different dynamic path' do
@@ -560,10 +560,10 @@ describe CarrierWave::Mongoid do
             uploader_class.remove_previously_stored_files_after_update = true
           end
 
-          it 'does not remove file if old file had the same path' do
+          it 'should not remove new file if both of files had the same path' do
             embedded_model.images = [stub_file('old.jpeg')]
             expect(embedded_model.save).to be_truthy
-            expect(File).to exist(public_path('uploads/old.jpeg'))
+            expect(File).to exist(embedded_model.images[0].path)
           end
 
           it 'does not remove file if validations fail on save' do
@@ -601,10 +601,10 @@ describe CarrierWave::Mongoid do
             uploader_class.remove_previously_stored_files_after_update = true
           end
 
-          it 'does not remove file if old file had the same path' do
+          it 'should not remove new file if both of files had the same path' do
             double_embedded_model.images = [stub_file('old.jpeg')]
             expect(double_embedded_model.save).to be_truthy
-            expect(File).to exist(public_path('uploads/old.jpeg'))
+            expect(File).to exist(double_embedded_model.images[0].path)
           end
 
           it 'does not remove file if validations fail on save' do
@@ -885,14 +885,14 @@ describe CarrierWave::Mongoid do
             expect(File).not_to exist(public_path('uploads/thumb_old.jpeg'))
           end
 
-          it 'does not remove file if old file had the same path' do
+          it 'does not remove new file if both of files had the same path' do
             expect(File).to exist(public_path('uploads/old.jpeg'))
             expect(File).to exist(public_path('uploads/thumb_old.jpeg'))
 
             model.update!(images: [stub_file('old.jpeg')])
 
-            expect(File).to exist(public_path('uploads/old.jpeg'))
-            expect(File).to exist(public_path('uploads/thumb_old.jpeg'))
+            expect(File).to exist(model.images[0].path)
+            expect(File).to exist(model.images[0].thumb.path)
           end
         end
 
@@ -933,7 +933,7 @@ describe CarrierWave::Mongoid do
             expect(File).not_to exist(public_path('uploads/old.txt'))
           end
 
-          it 'removes old file1 but not file2 if old file1 had a different path but old file2 has the same path' do
+          it 'removes old file1 but not new file2 if old file1 had a different path but old file2 has the same path' do
             expect(File).to exist(public_path('uploads/old.jpeg'))
             expect(File).to exist(public_path('uploads/old.txt'))
 
@@ -941,17 +941,17 @@ describe CarrierWave::Mongoid do
 
             expect(File).to exist(public_path('uploads/new.jpeg'))
             expect(File).not_to exist(public_path('uploads/old.jpeg'))
-            expect(File).to exist(public_path('uploads/old.txt'))
+            expect(File).to exist(model.textfiles[0].path)
           end
 
-          it 'does not remove file1 or file2 if file1 and file2 have the same paths' do
+          it 'does not remove new files if each pair of files has the same paths' do
             expect(File).to exist(public_path('uploads/old.jpeg'))
             expect(File).to exist(public_path('uploads/old.txt'))
 
             model.update!(images: [stub_file('old.jpeg')], textfiles: [stub_file('old.txt')])
 
-            expect(File).to exist(public_path('uploads/old.jpeg'))
-            expect(File).to exist(public_path('uploads/old.txt'))
+            expect(File).to exist(model.images[0].path)
+            expect(File).to exist(model.textfiles[0].path)
           end
         end
 
@@ -988,12 +988,12 @@ describe CarrierWave::Mongoid do
             expect(File).not_to exist(public_path('uploads/old.jpeg'))
           end
 
-          it 'does not remove file if old file had the same path' do
+          it 'does not remove new file if both of files had the same path' do
             expect(File).to exist(public_path('uploads/old.jpeg'))
 
             model.update!(avatars: [stub_file('old.jpeg')])
 
-            expect(File).to exist(public_path('uploads/old.jpeg'))
+            expect(File).to exist(model.avatars[0].path)
           end
         end
       end

--- a/spec/carrierwave/mongoid/mount_uploaders_spec.rb
+++ b/spec/carrierwave/mongoid/mount_uploaders_spec.rb
@@ -140,6 +140,7 @@ describe CarrierWave::Mongoid do
 
       describe 'model#remove_uploaders=' do
         before do
+          model.images = [stub_file('test.jpg')]
           model.save
         end
 
@@ -208,7 +209,7 @@ describe CarrierWave::Mongoid do
 
             before do
               model.save!
-              model.collection.update_one({ _id: model.id }, { images: identifiers })
+              model.collection.update_one({ _id: model.id }, '$set' => { images: identifiers })
             end
 
             it 'returns an array of uploaders' do
@@ -492,6 +493,8 @@ describe CarrierWave::Mongoid do
             expect(model.save).to be_truthy
             expect(File).to exist(public_path('uploads/new.jpeg'))
             expect(File).to exist(public_path('uploads/old.jpeg'))
+          ensure
+            uploader_class.remove_previously_stored_files_after_update = true
           end
 
           it 'does not remove file if old file had the same path' do
@@ -553,6 +556,8 @@ describe CarrierWave::Mongoid do
             expect(embedded_model.save).to be_truthy
             expect(File).to exist(public_path('uploads/new.jpeg'))
             expect(File).to exist(public_path('uploads/old.jpeg'))
+          ensure
+            uploader_class.remove_previously_stored_files_after_update = true
           end
 
           it 'does not remove file if old file had the same path' do
@@ -592,6 +597,8 @@ describe CarrierWave::Mongoid do
             expect(double_embedded_model.save).to be_truthy
             expect(File).to exist(public_path('uploads/new.jpeg'))
             expect(File).to exist(public_path('uploads/old.jpeg'))
+          ensure
+            uploader_class.remove_previously_stored_files_after_update = true
           end
 
           it 'does not remove file if old file had the same path' do

--- a/spec/carrierwave/mongoid/mount_uploaders_spec.rb
+++ b/spec/carrierwave/mongoid/mount_uploaders_spec.rb
@@ -382,15 +382,20 @@ describe CarrierWave::Mongoid do
 
         before do
           model_class.create!(images: files)
+          record.update!(images: [stub_file('test.jpeg')])
+          record.reload
         end
 
-        it 'replaced it by a file with the same name' do
-          record.update!(images: [stub_file('test.jpeg')])
-
-          record.reload
-
-          expect(record[:images]).to match_array(['test.jpeg'])
-          expect(record.images_identifiers).to match_array(['test.jpeg'])
+        if Gem::Version.new(CarrierWave::VERSION) >= Gem::Version.new("3.0.beta")
+          it "performs deduplication" do
+            expect(record[:images]).to match_array(['test(2).jpeg'])
+            expect(record.images_identifiers).to match_array(['test(2).jpeg'])
+          end
+        else
+          it 'replaced it by a file with the same name' do
+            expect(record[:images]).to match_array(['test.jpeg'])
+            expect(record.images_identifiers).to match_array(['test.jpeg'])
+          end
         end
       end
 

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -162,18 +162,15 @@ describe CarrierWave::Mongoid do
     end
 
     context "when a file is assigned" do
+      before do
+        @doc.image = stub_file('test.jpeg')
+      end
 
       it "should cache a file" do
-        @doc.image = stub_file('test.jpeg')
         expect(@doc.image).to be_an_instance_of(MongoUploader)
       end
 
-      it "should write nothing to the database, to prevent overridden filenames to fail because of unassigned attributes" do
-        expect(@doc[:image]).to be_nil
-      end
-
       it "should copy a file into into the cache directory" do
-        @doc.image = stub_file('test.jpeg')
         expect(@doc.image.current_path).to match /^#{public_path('uploads\/tmp')}/
       end
 

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -340,14 +340,21 @@ describe CarrierWave::Mongoid do
       @doc.image = stub_file('test.jpeg')
       @doc.save
       @doc.reload
-    end
-
-    it "replaced it by a file with the same name" do
       @doc.image = stub_file('test.jpeg')
       @doc.save
       @doc.reload
-      expect(@doc[:image]).to eq 'test.jpeg'
-      expect(@doc.image_identifier).to eq 'test.jpeg'
+    end
+
+    if Gem::Version.new(CarrierWave::VERSION) >= Gem::Version.new("3.0.beta")
+      it "performs deduplication" do
+        expect(@doc[:image]).to eq 'test(2).jpeg'
+        expect(@doc.image_identifier).to eq 'test(2).jpeg'
+      end
+    else
+      it "replaced it by a file with the same name" do
+        expect(@doc[:image]).to eq 'test.jpeg'
+        expect(@doc.image_identifier).to eq 'test.jpeg'
+      end
     end
 
   end

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -448,10 +448,10 @@ describe CarrierWave::Mongoid do
         @doc.image.class.remove_previously_stored_files_after_update = true
       end
 
-      it "should not remove file if old file had the same path" do
+      it 'should not remove new file if both of files had the same path' do
         @doc.image = stub_file('old.jpeg')
         expect(@doc.save).to be_truthy
-        expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
+        expect(File.exist?(@doc.image.path)).to be_truthy
       end
 
       it "should not remove file if validations fail on save" do
@@ -477,10 +477,10 @@ describe CarrierWave::Mongoid do
         expect(@doc.image.read).to eq "this is stuff"
       end
 
-      it "should not remove file if old file had the same dynamic path" do
+      it 'should not remove new file if both of files had the same path' do
         @doc.image = stub_file('test.jpeg')
         expect(@doc.save).to be_truthy
-        expect(File.exist?(public_path('uploads/test.jpeg'))).to be_truthy
+        expect(File.exist?(@doc.image.path)).to be_truthy
       end
 
       it "should remove old file if old file had a different dynamic path" do
@@ -510,10 +510,10 @@ describe CarrierWave::Mongoid do
         @embedded_doc.image.class.remove_previously_stored_files_after_update = true
       end
 
-      it "should not remove file if old file had the same path" do
+      it 'should not remove new file if both of files had the same path' do
         @embedded_doc.image = stub_file('old.jpeg')
         expect(@embedded_doc.save).to be_truthy
-        expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
+        expect(File.exist?(@embedded_doc.image.path)).to be_truthy
       end
 
       it "should not remove file if validations fail on save" do
@@ -550,10 +550,10 @@ describe CarrierWave::Mongoid do
         @double_embedded_doc.image.class.remove_previously_stored_files_after_update = true
       end
 
-      it "should not remove file if old file had the same path" do
+      it 'should not remove new file if both of files had the same path' do
         @double_embedded_doc.image = stub_file('old.jpeg')
         expect(@double_embedded_doc.save).to be_truthy
-        expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
+        expect(File.exist?(@double_embedded_doc.image.path)).to be_truthy
       end
 
       it "should not remove file if validations fail on save" do
@@ -790,11 +790,11 @@ describe CarrierWave::Mongoid do
       expect(File.exist?(public_path('uploads/thumb_old.jpeg'))).to be_falsey
     end
 
-    it "should not remove file if old file had the same path" do
+    it 'should not remove new file if both of files had the same path' do
       @doc.image = stub_file('old.jpeg')
       expect(@doc.save).to be_truthy
-      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
-      expect(File.exist?(public_path('uploads/thumb_old.jpeg'))).to be_truthy
+      expect(File.exist?(@doc.image.path)).to be_truthy
+      expect(File.exist?(@doc.image.thumb.path)).to be_truthy
     end
   end
 
@@ -827,21 +827,21 @@ describe CarrierWave::Mongoid do
       expect(File.exist?(public_path('uploads/old.txt'))).to be_falsey
     end
 
-    it "should remove old file1 but not file2 if old file1 had a different path but old file2 has the same path" do
+    it "should remove old file1 but not new file2 if old file1 had a different path but old file2 has the same path" do
       @doc.image = stub_file('new.jpeg')
       @doc.textfile = stub_file('old.txt')
       expect(@doc.save).to be_truthy
       expect(File.exist?(public_path('uploads/new.jpeg'))).to be_truthy
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_falsey
-      expect(File.exist?(public_path('uploads/old.txt'))).to be_truthy
+      expect(File.exist?(@doc.textfile.path)).to be_truthy
     end
 
-    it "should not remove file1 or file2 if file1 and file2 have the same paths" do
+    it "should not remove new files if each pair of files has the same paths" do
       @doc.image = stub_file('old.jpeg')
       @doc.textfile = stub_file('old.txt')
       expect(@doc.save).to be_truthy
-      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
-      expect(File.exist?(public_path('uploads/old.txt'))).to be_truthy
+      expect(File.exist?(@doc.image.path)).to be_truthy
+      expect(File.exist?(@doc.textfile.path)).to be_truthy
     end
   end
 
@@ -868,10 +868,10 @@ describe CarrierWave::Mongoid do
       expect(File.exist?(public_path('uploads/old.jpeg'))).to be_falsey
     end
 
-    it "should not remove file if old file had the same path" do
+    it 'should not remove new file if both of files had the same path' do
       @doc.avatar = stub_file('old.jpeg')
       expect(@doc.save).to be_truthy
-      expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
+      expect(File).to exist(@doc.avatar.path)
     end
   end
 

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -237,6 +237,8 @@ describe CarrierWave::Mongoid do
     before do
       mongo_user_klass = reset_mongo_class
       @doc = mongo_user_klass.new
+      @doc.image = stub_file('test.jpg')
+      @doc.save!
     end
 
     it "treats true argument such that attribute is marked as changed" do
@@ -442,6 +444,8 @@ describe CarrierWave::Mongoid do
         expect(@doc.save).to be_truthy
         expect(File.exist?(public_path('uploads/new.jpeg'))).to be_truthy
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
+      ensure
+        @doc.image.class.remove_previously_stored_files_after_update = true
       end
 
       it "should not remove file if old file had the same path" do
@@ -502,6 +506,8 @@ describe CarrierWave::Mongoid do
         expect(@embedded_doc.save).to be_truthy
         expect(File.exist?(public_path('uploads/new.jpeg'))).to be_truthy
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
+      ensure
+        @embedded_doc.image.class.remove_previously_stored_files_after_update = true
       end
 
       it "should not remove file if old file had the same path" do
@@ -540,6 +546,8 @@ describe CarrierWave::Mongoid do
         expect(@double_embedded_doc.save).to be_truthy
         expect(File.exist?(public_path('uploads/new.jpeg'))).to be_truthy
         expect(File.exist?(public_path('uploads/old.jpeg'))).to be_truthy
+      ensure
+        @double_embedded_doc.image.class.remove_previously_stored_files_after_update = true
       end
 
       it "should not remove file if old file had the same path" do


### PR DESCRIPTION
This PR aims to make carrierwave-mongoid to work with CarrierWave 3.x, while keeping the support for older CarrierWave versions. Changes are separeted into several commits, to describe the intention better.