### PR TITLE
Explicitly require `logger` library in `spec_helper`

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'bundler/setup'
 require 'rspec'
 require 'tempfile'
 require 'stringio'
+require 'logger'
 
 require 'carrierwave'
 require 'carrierwave/mongoid'


### PR DESCRIPTION
The CI pipeline is current failing for certain matrix configurations that rely on `ActiveSupport` < 7.1:

```
An error occurred while loading ./spec/storage/grid_fs_spec.rb.
Failure/Error: require 'carrierwave'

NameError:
  uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger
# ./vendor/bundle/ruby/2.6.0/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:16:in `<module:LoggerThreadSafeLevel>'
# ./vendor/bundle/ruby/2.6.0/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:9:in `<module:ActiveSupport>'
# ./vendor/bundle/ruby/2.6.0/gems/activesupport-6.1.7.10/lib/active_support/logger_thread_safe_level.rb:8:in `<top (required)>'
# ./vendor/bundle/ruby/2.6.0/gems/activesupport-6.1.7.10/lib/active_support/logger_silence.rb:5:in `require'
# ./vendor/bundle/ruby/2.6.0/gems/activesupport-6.1.7.10/lib/active_support/logger_silence.rb:5:in `<top (required)>'
# ./vendor/bundle/ruby/2.6.0/gems/activesupport-6.1.7.10/lib/active_support/logger.rb:3:in `require'
# ./vendor/bundle/ruby/2.6.0/gems/activesupport-6.1.7.10/lib/active_support/logger.rb:3:in `<top (required)>'
# ./vendor/bundle/ruby/2.6.0/gems/activesupport-6.1.7.10/lib/active_support.rb:29:in `require'
# ./vendor/bundle/ruby/2.6.0/gems/activesupport-6.1.7.10/lib/active_support.rb:29:in `<top (required)>'
# ./vendor/bundle/ruby/2.6.0/gems/carrierwave-3.0.7/lib/carrierwave/uploader/file_size.rb:1:in `require'
# ./vendor/bundle/ruby/2.6.0/gems/carrierwave-3.0.7/lib/carrierwave/uploader/file_size.rb:1:in `<top (required)>'
# ./vendor/bundle/ruby/2.6.0/gems/carrierwave-3.0.7/lib/carrierwave/uploader.rb:14:in `require'
# ./vendor/bundle/ruby/2.6.0/gems/carrierwave-3.0.7/lib/carrierwave/uploader.rb:14:in `<top (required)>'
# ./vendor/bundle/ruby/2.6.0/gems/carrierwave-3.0.7/lib/carrierwave.rb:97:in `require'
# ./vendor/bundle/ruby/2.6.0/gems/carrierwave-3.0.7/lib/carrierwave.rb:97:in `<top (required)>'
# ./spec/spec_helper.rb:7:in `require'
# ./spec/spec_helper.rb:7:in `<top (required)>'
```

This is because prior to 7.1, `ActiveSupport` was relying on `concurrent-ruby` to require the `logger` library, but `concurrent-ruby` stopped requiring `logger` starting in version 1.3.5.

This issue was fixed in https://github.com/rails/rails/pull/54264.

The only place in `carrierwave-mongoid` that references `Logger` is here:

https://github.com/carrierwaveuploader/carrierwave-mongoid/blob/0f95a6cd96cf384f73a63fdec428248b17d9ecfa/spec/spec_helper.rb#L15

So, requiring `logger` in `spec_helper.rb` fixes the failing CI matrix configurations.